### PR TITLE
Adds support for CZI with JPEG XR compression

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ This project:
 - [QuPath integration](./qupath-extension-classpose) with UI, live logging, and auto-import.
 - [Docker](https://hub.docker.com/repository/docker/josegcpa/classpose/general)
 - [Nextflow pipeline](https://github.com/adamjtaylor/nf-classpose) implemented by [Adam Taylor](https://github.com/adamjtaylor)
-- CZI reader ([`CZISlide`](./src/classpose/wsi_utils.py)) using the [official library from Zeiss](https://github.com/ZEISS/pylibczirw/). This enables Classpose to interact with JPEG XR-compressed files (currently unsupported by OpenSlide) using an interface identical to that of OpenSlide. **Note:** this is experimental and has not been extensively tested.
+- CZI reader ([`CZISlide`](./src/classpose/wsi_utils.py)) using the [official library from Zeiss](https://github.com/ZEISS/pylibczirw/). This enables Classpose to interact with JPEG XR-compressed files (currently unsupported by OpenSlide) using an interface identical to that of OpenSlide. Triggering the use of `CZISlide` requires setting the environment variable `WSI_READER=czi-zeiss` (the default value is `"openslide"`). **Note:** this is experimental and has not been extensively tested.
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -19,9 +19,10 @@ This project:
 - Adds a semantic head to leverage generalist Cellpose weights for classification.
 - WSI pipeline with tissue and optional artefact detection (GrandQC-based components in `src/classpose/grandqc/`).
 - CLI entrypoint: `classpose-predict-wsi` (also available via `python -m classpose.entrypoints.predict_wsi`).
-- QuPath integration: [qupath-extension-classpose](./qupath-extension-classpose) with UI, live logging, and auto-import.
+- [QuPath integration](./qupath-extension-classpose) with UI, live logging, and auto-import.
 - [Docker](https://hub.docker.com/repository/docker/josegcpa/classpose/general)
 - [Nextflow pipeline](https://github.com/adamjtaylor/nf-classpose) implemented by [Adam Taylor](https://github.com/adamjtaylor)
+- CZI reader ([`CZISlide`](./src/classpose/wsi_utils.py)) using the [official library from Zeiss](https://github.com/ZEISS/pylibczirw/). This enables Classpose to interact with JPEG XR-compressed files (currently unsupported by OpenSlide) using an interface identical to that of OpenSlide. **Note:** this is experimental and has not been extensively tested.
 
 ## Installation
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,9 @@ notebook = [
     "matplotlib>=3.10.1",
     "notebook>=7.4.0",
 ]
+czi-zeiss = [
+    "pylibczirw>=5.1.1",
+]
 
 [build-system]
 requires = ["setuptools>=61.0"]

--- a/pytest.toml
+++ b/pytest.toml
@@ -1,5 +1,5 @@
 [pytest]
-addopts = ["-ra", "-q"]
+addopts = ["-ra"]
 testpaths = [
     "tests",
 ]

--- a/src/classpose/__init__.py
+++ b/src/classpose/__init__.py
@@ -1,3 +1,44 @@
-from classpose.wsi_utils import WSIReader
+import os
+from classpose.log import get_logger
+
+logger = get_logger(__name__)
+
+WSI_READERS = ["czi-zeiss", "openslide"]
+
+
+def get_wsi_reader(reader_str: str):
+    """
+    Get a WSI reader for the given path.
+
+    Args:
+        reader_str (str): path to the WSI file.
+
+    Returns:
+        WSI reader class (either OpenSlide or CZISlide).
+    """
+    if reader_str not in WSI_READERS:
+        readers = list(WSI_READERS.keys())
+        err = f"Reader {reader_str} not supported. "
+        err += f"Should be one of {readers}"
+        logger.error(err)
+        raise ValueError(err)
+    if reader_str == "czi-zeiss":
+        try:
+            from classpose.wsi_utils import CZISlide
+        except ImportError:
+            err = "czi-zeiss reader requires pylibCZIrw"
+            logger.error(err)
+            raise ImportError(err)
+        return CZISlide
+    elif reader_str == "openslide":
+        from openslide import OpenSlide
+
+        return OpenSlide
+
+
+def WSIReader(*args, **kwargs):
+    reader_str = os.environ.get("WSI_READER", "openslide")
+    return get_wsi_reader(reader_str)(*args, **kwargs)
+
 
 __all__ = ["WSIReader"]

--- a/src/classpose/__init__.py
+++ b/src/classpose/__init__.py
@@ -17,7 +17,7 @@ def get_wsi_reader(reader_str: str):
         WSI reader class (either OpenSlide or CZISlide).
     """
     if reader_str not in WSI_READERS:
-        readers = list(WSI_READERS.keys())
+        readers = WSI_READERS
         err = f"Reader {reader_str} not supported. "
         err += f"Should be one of {readers}"
         logger.error(err)

--- a/src/classpose/__init__.py
+++ b/src/classpose/__init__.py
@@ -1,0 +1,3 @@
+from classpose.wsi_utils import WSIReader
+
+__all__ = ["WSIReader"]

--- a/src/classpose/entrypoints/outputs.py
+++ b/src/classpose/entrypoints/outputs.py
@@ -304,11 +304,11 @@ def flatten_geojson_properties(gdf: gpd.GeoDataFrame) -> gpd.GeoDataFrame:
 
         for measure in ["area", "perimeter", "centroidX", "centroidY"]:
             gdf[measure] = parsed_measurements.apply(
-                lambda x: next(
-                    (m["value"] for m in x if m["name"] == measure), None
+                lambda x: (
+                    next((m["value"] for m in x if m["name"] == measure), None)
+                    if isinstance(x, list)
+                    else None
                 )
-                if isinstance(x, list)
-                else None
             )
         gdf = gdf.drop(columns=["measurements"])
 

--- a/src/classpose/entrypoints/predict_wsi.py
+++ b/src/classpose/entrypoints/predict_wsi.py
@@ -78,6 +78,7 @@ from classpose.entrypoints.outputs import (
     create_valid_polygon,
     map_cells_to_roi_classes,
 )
+from classpose import WSIReader
 
 logger = get_logger("classpose")
 
@@ -180,7 +181,7 @@ class SlideLoader:
         return self.real_slide_path
 
     def _init_slide(self):
-        self.slide = OpenSlide(self.get_real_slide_path())
+        self.slide = WSIReader(self.get_real_slide_path())
         self.mpp = get_slide_resolution(self.slide)
         self.mpp_x.value = self.mpp[0]
         self.mpp_y.value = self.mpp[1]
@@ -188,7 +189,9 @@ class SlideLoader:
         bounds_y = self.slide.properties.get("openslide.bounds-y")
         self.bounds_x.value = float(bounds_x) if bounds_x is not None else 0.0
         self.bounds_y.value = float(bounds_y) if bounds_y is not None else 0.0
-        logger.info(f"Slide bounds offset: x={self.bounds_x.value}, y={self.bounds_y.value}")
+        logger.info(
+            f"Slide bounds offset: x={self.bounds_x.value}, y={self.bounds_y.value}"
+        )
 
         if self.roi_tree is not None and (
             self.bounds_x.value != 0 or self.bounds_y.value != 0
@@ -226,19 +229,23 @@ class SlideLoader:
         """
         Align ROI polygons to slide coordinates when OpenSlide bounds offsets are present.
 
-        QuPath ROI annotations are exported in coordinates relative to the displayed image 
-        origin (i.e. bounds-offset corrected). Internal OpenSlide tile coordinates are in 
-        level-0 slide space. So if needed, shift ROI polygons by +bounds offsets so 
+        QuPath ROI annotations are exported in coordinates relative to the displayed image
+        origin (i.e. bounds-offset corrected). Internal OpenSlide tile coordinates are in
+        level-0 slide space. So if needed, shift ROI polygons by +bounds offsets so
         ROI-based tile selection/filtering uses the same frame.
         """
         bounds_x_val = float(self.bounds_x.value)
         bounds_y_val = float(self.bounds_y.value)
         geometries = list(self.roi_tree.geometries)
 
-        logger.info(f"Applying bounds offset to ROI polygons: x={bounds_x_val}, y={bounds_y_val}")
+        logger.info(
+            f"Applying bounds offset to ROI polygons: x={bounds_x_val}, y={bounds_y_val}"
+        )
 
         shifted = [
-            shapely.affinity.translate(geom, xoff=bounds_x_val, yoff=bounds_y_val)
+            shapely.affinity.translate(
+                geom, xoff=bounds_x_val, yoff=bounds_y_val
+            )
             for geom in geometries
         ]
         self.roi_tree = shapely.STRtree(shifted)
@@ -247,7 +254,7 @@ class SlideLoader:
         if self.tissue_detection_model_path is not None:
             logger.info("Detecting tissue contours using GrandQC")
             _, _, _, tissue_cnts, _, _ = detect_tissue_wsi(
-                slide=OpenSlide(self.get_real_slide_path()),
+                slide=WSIReader(self.get_real_slide_path()),
                 model_td_path=self.tissue_detection_model_path,
                 min_area=self.min_area,
                 device=self.device,
@@ -350,7 +357,10 @@ class SlideLoader:
         """
         self._init_slide()
         self._get_tissue_contours()
-        if self.tissue_detection_model_path is not None and not self.tissue_cnts:
+        if (
+            self.tissue_detection_model_path is not None
+            and not self.tissue_cnts
+        ):
             logger.warning("No tissue detected in slide. Skipping inference.")
             for _ in range(self.n_none):
                 self.q.put((None, None))
@@ -658,41 +668,42 @@ def to_geojson_polygon(curr_cell: dict) -> dict:
     return curr_cell
 
 
-def apply_bounds_offset_to_feature(feature: dict, bounds_x: float, bounds_y: float) -> dict:
+def apply_bounds_offset_to_feature(
+    feature: dict, bounds_x: float, bounds_y: float
+) -> dict:
     """
     Apply bounds offset to a GeoJSON Polygon feature's geometry and centroid measurements.
-    
+
     Args:
         feature: GeoJSON Feature dict with Polygon geometry
         bounds_x: X offset from openslide.bounds-x property
         bounds_y: Y offset from openslide.bounds-y property
-        
+
     Returns:
         Feature with shifted polygon coordinates and updated centroid measurements.
     """
     if not feature or "geometry" not in feature:
         return feature
-    
+
     geometry = feature["geometry"]
     if "coordinates" not in geometry:
         return feature
-    
+
     shifted_coordinates = []
     for ring in geometry["coordinates"]:
         shifted_ring = [
-            [point[0] - bounds_x, point[1] - bounds_y]
-            for point in ring
+            [point[0] - bounds_x, point[1] - bounds_y] for point in ring
         ]
         shifted_coordinates.append(shifted_ring)
     geometry["coordinates"] = shifted_coordinates
-    
+
     if "properties" in feature and "measurements" in feature["properties"]:
         for measurement in feature["properties"]["measurements"]:
             if measurement["name"] == "centroidX":
                 measurement["value"] -= bounds_x
             elif measurement["name"] == "centroidY":
                 measurement["value"] -= bounds_y
-    
+
     return feature
 
 
@@ -826,9 +837,11 @@ def shapely_polygon_to_geojson(
 
 def load_roi_polygons(
     roi_geojson_path: str, group_by_class: bool = False
-) -> shapely.STRtree | tuple[
-    shapely.STRtree, dict[str, list[shapely.Polygon]]
-] | None:
+) -> (
+    shapely.STRtree
+    | tuple[shapely.STRtree, dict[str, list[shapely.Polygon]]]
+    | None
+):
     """
     Load ROI polygons from a GeoJSON file (FeatureCollection).
 
@@ -1340,7 +1353,9 @@ def main(args):
         bounds_y_val = float(slide.bounds_y.value)
         if bounds_x_val != 0 or bounds_y_val != 0:
             tissue_cnts = [
-                shapely.affinity.translate(cnt, xoff=-bounds_x_val, yoff=-bounds_y_val)
+                shapely.affinity.translate(
+                    cnt, xoff=-bounds_x_val, yoff=-bounds_y_val
+                )
                 for cnt in tissue_cnts
             ]
 
@@ -1384,7 +1399,7 @@ def main(args):
                 artefact_cnts,
                 artefact_geojson,
             ) = detect_artefacts_wsi(
-                slide=OpenSlide(slide.get_real_slide_path()),
+                slide=WSIReader(slide.get_real_slide_path()),
                 model_art_path=args.artefact_detection_model_path,
                 model_td_path=args.tissue_detection_model_path,
                 device=devices[0],
@@ -1414,12 +1429,13 @@ def main(args):
                     if polygon is not None:
                         artefact_polygons.append(polygon)
 
-        
         bounds_x_val = float(slide.bounds_x.value)
         bounds_y_val = float(slide.bounds_y.value)
         if bounds_x_val != 0 or bounds_y_val != 0:
             artefact_polygons = [
-                shapely.affinity.translate(poly, xoff=-bounds_x_val, yoff=-bounds_y_val)
+                shapely.affinity.translate(
+                    poly, xoff=-bounds_x_val, yoff=-bounds_y_val
+                )
                 for poly in artefact_polygons
             ]
 
@@ -1455,7 +1471,9 @@ def main(args):
     bounds_x_val = float(slide.bounds_x.value)
     bounds_y_val = float(slide.bounds_y.value)
     if bounds_x_val != 0 or bounds_y_val != 0:
-        logger.info(f"Applying bounds offset to output coordinates: x={bounds_x_val}, y={bounds_y_val}")
+        logger.info(
+            f"Applying bounds offset to output coordinates: x={bounds_x_val}, y={bounds_y_val}"
+        )
         polygons = [
             apply_bounds_offset_to_feature(f, bounds_x_val, bounds_y_val)
             for f in polygons

--- a/src/classpose/entrypoints/predict_wsi_cpsam.py
+++ b/src/classpose/entrypoints/predict_wsi_cpsam.py
@@ -86,6 +86,7 @@ from classpose.utils import (
     get_device,
     get_geojson_output_filename,
 )
+from classpose import WSIReader
 
 logger = get_logger("classpose")
 
@@ -499,7 +500,7 @@ def main(args):
                 artefact_cnts,
                 artefact_geojson,
             ) = detect_artefacts_wsi(
-                slide=OpenSlide(slide.get_real_slide_path()),
+                slide=WSIReader(slide.get_real_slide_path()),
                 model_art_path=args.artefact_detection_model_path,
                 model_td_path=args.tissue_detection_model_path,
                 device=devices[0],

--- a/src/classpose/grandqc/wsi_artefact_detection.py
+++ b/src/classpose/grandqc/wsi_artefact_detection.py
@@ -1,5 +1,5 @@
 import json
-from typing import Any
+from typing import Any, Union
 
 import cv2
 import numpy as np
@@ -23,7 +23,6 @@ from classpose.utils import (
     get_device,
     get_geojson_output_path_from_prefix,
 )
-from classpose.wsi_utils import CZISlide
 from classpose import WSIReader
 
 grandqc_logger = get_logger(__name__)
@@ -55,7 +54,7 @@ ARTIFACT_CLASS_MAPPING = {
 
 
 def detect_artefacts_wsi(
-    slide: OpenSlide | CZISlide,
+    slide: Union[OpenSlide, "CZISlide"],
     # artefact detection model parameters
     model_art_path: str = "./models/artefact_detection/GrandQC_MPP1.pth",
     mpp_model_art: float = 1.0,

--- a/src/classpose/grandqc/wsi_artefact_detection.py
+++ b/src/classpose/grandqc/wsi_artefact_detection.py
@@ -23,6 +23,8 @@ from classpose.utils import (
     get_device,
     get_geojson_output_path_from_prefix,
 )
+from classpose.wsi_utils import CZISlide
+from classpose import WSIReader
 
 grandqc_logger = get_logger(__name__)
 
@@ -53,7 +55,7 @@ ARTIFACT_CLASS_MAPPING = {
 
 
 def detect_artefacts_wsi(
-    slide: OpenSlide,
+    slide: OpenSlide | CZISlide,
     # artefact detection model parameters
     model_art_path: str = "./models/artefact_detection/GrandQC_MPP1.pth",
     mpp_model_art: float = 1.0,
@@ -71,15 +73,15 @@ def detect_artefacts_wsi(
     """
     Detects artefacts in a whole-slide image using GrandQC method.
     First performs tissue detection, then artefact segmentation on tissue areas.
-    
-    Please note that if you use any part of Classpose which makes use of GrandQC please 
-    follow the instructions at https://github.com/cpath-ukk/grandqc/tree/main to cite them 
-    appropriately. Similarly to Classpose, GrandQC is under a non-commercial license 
+
+    Please note that if you use any part of Classpose which makes use of GrandQC please
+    follow the instructions at https://github.com/cpath-ukk/grandqc/tree/main to cite them
+    appropriately. Similarly to Classpose, GrandQC is under a non-commercial license
     whose terms can be found at https://github.com/cpath-ukk/grandqc/blob/main/LICENSE.
 
 
     Args:
-        slide (OpenSlide): slide to detect artefacts in.
+        slide (OpenSlide | CZISlide): slide to detect artefacts in.
         model_art_path (str): path to the artefact detection model.
         mpp_model_art (float): MPP of the artefact detection model (default 1.0).
         m_p_s_model_art (int): patch size of the artefact model.
@@ -91,7 +93,7 @@ def detect_artefacts_wsi(
         m_p_s_model_td (int): patch size for tissue detection.
         min_area (int): minimum area for tissue polygons.
         apply_bounds_offset (bool): if True, shift artefact contours and
-        GeoJSON by OpenSlide bounds offsets, so output coordinates are 
+        GeoJSON by OpenSlide bounds offsets, so output coordinates are
         relative to the displayed image origin. Defaults to False.
 
     Returns:
@@ -329,7 +331,8 @@ def detect_artefacts_wsi(
             cnt["contour"] = cnt["contour"] - np.array([bounds_x, bounds_y])
             if cnt["holes"]:
                 cnt["holes"] = [
-                    hole - np.array([bounds_x, bounds_y]) for hole in cnt["holes"]
+                    hole - np.array([bounds_x, bounds_y])
+                    for hole in cnt["holes"]
                 ]
 
         for feature in geojson["features"]:
@@ -395,7 +398,7 @@ if __name__ == "__main__":
     args = parser.parse_args()
     args.device = get_device(args.device)[0]
 
-    slide = OpenSlide(args.slide_path)
+    slide = WSIReader(args.slide_path)
     artefact_mask, artefact_map, artefact_cnts, geojson = detect_artefacts_wsi(
         slide,
         mpp_model_art=args.mpp_model_art,

--- a/src/classpose/grandqc/wsi_tissue_detection.py
+++ b/src/classpose/grandqc/wsi_tissue_detection.py
@@ -1,7 +1,6 @@
 import json
-import os
 import uuid
-from typing import Any
+from typing import Any, Union
 
 import cv2
 import numpy as np
@@ -21,7 +20,6 @@ from classpose.utils import (
     get_device,
     get_geojson_output_path_from_prefix,
 )
-from classpose.wsi_utils import CZISlide
 from classpose import WSIReader
 
 grandqc_logger = get_logger(__name__)
@@ -32,7 +30,7 @@ MODEL_URL_PATH = (
 
 
 def detect_tissue_wsi(
-    slide: OpenSlide | CZISlide,
+    slide: Union[OpenSlide, "CZISlide"],
     # tissue detection model parameters
     model_td_path: str = "./models/tissue_detection/Tissue_Detection_MPP10.pth",
     mpp_model_td: int = 10,

--- a/src/classpose/grandqc/wsi_tissue_detection.py
+++ b/src/classpose/grandqc/wsi_tissue_detection.py
@@ -1,4 +1,5 @@
 import json
+import os
 import uuid
 from typing import Any
 
@@ -20,6 +21,8 @@ from classpose.utils import (
     get_device,
     get_geojson_output_path_from_prefix,
 )
+from classpose.wsi_utils import CZISlide
+from classpose import WSIReader
 
 grandqc_logger = get_logger(__name__)
 
@@ -29,7 +32,7 @@ MODEL_URL_PATH = (
 
 
 def detect_tissue_wsi(
-    slide: OpenSlide,
+    slide: OpenSlide | CZISlide,
     # tissue detection model parameters
     model_td_path: str = "./models/tissue_detection/Tissue_Detection_MPP10.pth",
     mpp_model_td: int = 10,
@@ -43,13 +46,13 @@ def detect_tissue_wsi(
 ) -> tuple[Image, np.ndarray, np.ndarray, list[np.ndarray], dict[str, Any],]:
     """
     Detects tissue in a whole-slide image using a U-Net model. This is adapted
-    from the GrandQC repository. Please note that if you use any part of Classpose 
-    which makes use of GrandQC please follow the instructions at https://github.com/cpath-ukk/grandqc/tree/main 
-    to cite them appropriately. Similarly to Classpose, GrandQC is under a non-commercial license 
+    from the GrandQC repository. Please note that if you use any part of Classpose
+    which makes use of GrandQC please follow the instructions at https://github.com/cpath-ukk/grandqc/tree/main
+    to cite them appropriately. Similarly to Classpose, GrandQC is under a non-commercial license
     whose terms can be found at https://github.com/cpath-ukk/grandqc/blob/main/LICENSE.
 
     Args:
-        slide (OpenSlide): slide to detect tissue in.
+        slide (OpenSlide | CZISlide): slide to detect tissue in.
         model_td_path (str, optional): path to the tissue detection model.
             Defaults to "./models/tissue_detection/Tissue_Detection_MPP10.pth".
         mpp_model_td (int, optional): MPP of the tissue detection model.
@@ -64,7 +67,7 @@ def detect_tissue_wsi(
         min_area (int, optional): minimum area of the tissue polygons. Defaults
             to 0.
         apply_bounds_offset (bool, optional): if True, shift output contours and
-        GeoJSON by OpenSlide bounds offsets, so output coordinates are relative 
+        GeoJSON by OpenSlide bounds offsets, so output coordinates are relative
         to the displayed image origin. Defaults to False.
 
     Returns:
@@ -228,7 +231,14 @@ def detect_tissue_wsi(
         del model
         del preprocessing_fn
         del slide
-        return (image, filtered_mask, filled_class_map, {}, empty_geojson, mpp_model_td)
+        return (
+            image,
+            filtered_mask,
+            filled_class_map,
+            {},
+            empty_geojson,
+            mpp_model_td,
+        )
 
     holes_idx = np.where(hierarchy[0, :, 3] != -1)[0]
     scaling_array = np.array([observed_reduction_w, observed_reduction_h])
@@ -296,7 +306,8 @@ def detect_tissue_wsi(
             cnt["contour"] = cnt["contour"] - np.array([bounds_x, bounds_y])
             if cnt["holes"]:
                 cnt["holes"] = [
-                    hole - np.array([bounds_x, bounds_y]) for hole in cnt["holes"]
+                    hole - np.array([bounds_x, bounds_y])
+                    for hole in cnt["holes"]
                 ]
 
         for feature in geojson["features"]:
@@ -357,7 +368,7 @@ if __name__ == "__main__":
     args = parser.parse_args()
     args.device = get_device(args.device)[0]
 
-    slide = OpenSlide(args.slide_path)
+    slide = WSIReader(args.slide_path)
     image, mask, filled_class_map, _, geojson, mpp_model_td = detect_tissue_wsi(
         slide,
         model_td_path=args.model_path,

--- a/src/classpose/wsi_utils.py
+++ b/src/classpose/wsi_utils.py
@@ -130,7 +130,7 @@ class CZISlide:
             int: Best level.
         """
         for i, ds in enumerate(self.level_downsamples):
-            if downsample < ds:
+            if downsample <= ds:
                 return i
         return i
 

--- a/src/classpose/wsi_utils.py
+++ b/src/classpose/wsi_utils.py
@@ -41,10 +41,12 @@ class CZISlide:
             "h": bbp["Y"][1] - bbp["Y"][0],
         }
         bb = self._czi.total_bounding_box
-        bounding_rect = self._czi.scenes_bounding_rectangle[0]
+        bounding_rects = self._czi.scenes_bounding_rectangle
+        bounding_rect = bounding_rects[0]
         logger.info(f"Total bounding box: {bb}")
         logger.info(f"Scenes bounding rectangle: {bounding_rect}")
         logger.info(f"Bounding box (layer 0): {bbp}")
+        logger.info(f"Bounding rectangles: {bounding_rects}")
         self._x_min = bbp["x"]
         self._y_min = bbp["y"]
         w = bbp["w"]

--- a/src/classpose/wsi_utils.py
+++ b/src/classpose/wsi_utils.py
@@ -1,8 +1,6 @@
-import os
 import numpy as np
 from PIL import Image
 from pylibCZIrw import czi as pyczi
-from openslide import OpenSlide
 
 from classpose.log import get_logger
 
@@ -142,33 +140,3 @@ class CZISlide:
 
     def __exit__(self, *args):
         self.close()
-
-
-WSI_READERS = {
-    "czi-zeiss": CZISlide,
-    "openslide": OpenSlide,
-}
-
-
-def get_wsi_reader(reader_str: str) -> CZISlide:
-    """
-    Get a WSI reader for the given path.
-
-    Args:
-        reader_str (str): path to the WSI file.
-
-    Returns:
-        CZISlide: WSI reader.
-    """
-    if reader_str not in WSI_READERS:
-        readers = list(WSI_READERS.keys())
-        err = f"Reader {reader_str} not supported. "
-        err += f"Should be one of {readers}"
-        logger.error(err)
-        raise ValueError(err)
-    return WSI_READERS[reader_str]
-
-
-def WSIReader(*args, **kwargs):
-    reader_str = os.environ.get("WSI_READER", "openslide")
-    return get_wsi_reader(reader_str)(*args, **kwargs)

--- a/src/classpose/wsi_utils.py
+++ b/src/classpose/wsi_utils.py
@@ -1,0 +1,174 @@
+import os
+import numpy as np
+from PIL import Image
+from pylibCZIrw import czi as pyczi
+from openslide import OpenSlide
+
+from classpose.log import get_logger
+
+logger = get_logger(__name__)
+
+
+class CZISlide:
+    """
+    OpenSlide-like interface for CZI files using pylibCZIrw.
+    """
+
+    def __init__(self, path: str):
+        """
+        Initialize a CZI slide.
+
+        Args:
+            path (str): path to the CZI file.
+        """
+        self._path = path
+        # open_czi returns a context manager, so we have to consume it
+        self._czi = pyczi.CziReader(path)
+        metadata = self._czi.metadata["ImageDocument"]["Metadata"]
+        distance = metadata["Scaling"]["Items"]["Distance"]
+        mpp_x = (
+            float([x for x in distance if x["@Id"] == "X"][0]["Value"]) / 1e-6
+        )
+        mpp_y = (
+            float([x for x in distance if x["@Id"] == "Y"][0]["Value"]) / 1e-6
+        )
+        logger.info(f"MPP X: {mpp_x}, MPP Y: {mpp_y}")
+
+        # Build level dimensions (scene 0, channel 0 by default)
+        stats = self._czi._czi_reader.GetSubBlockStats()
+        bb0 = stats.boundingBoxLayer0Only
+        bb0 = {
+            "x": bb0.x,
+            "y": bb0.y,
+            "w": bb0.w,
+            "h": bb0.h,
+        }
+        bb = self._czi.total_bounding_box
+        bounding_rect = self._czi.scenes_bounding_rectangle[0]
+        logger.info(f"Total bounding box: {bb}")
+        logger.info(f"Scenes bounding rectangle: {bounding_rect}")
+        logger.info(f"Bounding box (layer 0): {bb0}")
+        self._x_min = bb0["x"]
+        self._y_min = bb0["y"]
+        w = bb0["w"]
+        h = bb0["h"]
+
+        self.level_downsamples = [1, 2, 4, 8, 16]
+        self.level_dimensions = [
+            (w // ds, h // ds) for ds in self.level_downsamples
+        ]
+        self.level_count = len(self.level_dimensions)
+
+        # Expose basic properties
+        self.properties = {
+            "openslide.vendor": "zeiss",
+            "openslide.mpp-x": mpp_x,
+            "openslide.mpp-y": mpp_y,
+            # we are currently processing bounds internally, so this is set to 0
+            # to avoid double offset
+            "openslide.bounds-x": 0,
+            "openslide.bounds-y": 0,
+            "openslide.real-bounds-x": -self._x_min,
+            "openslide.real-bounds-y": -self._y_min,
+        }
+
+    def read_region(
+        self, location: tuple, level: int, size: tuple
+    ) -> np.ndarray:
+        """
+        Read a region from the CZI file.
+
+        Args:
+            location (tuple): (x, y) in level-0 pixel coordinates (top-left corner).
+            level (int): Pyramid level (0 = full resolution).
+            size (tuple): (width, height) of the region to read.
+
+        Returns:
+            np.ndarray: Array of shape (height, width, channels), dtype uint8.
+        """
+        x, y = location
+        w, h = size
+        downsample = self.level_downsamples[level]
+
+        # Scale location to level-0 coordinates then offset by CZI origin
+        roi = (
+            int(x) + self._x_min,
+            int(y) + self._y_min,
+            int(w * downsample),
+            int(h * downsample),
+        )
+
+        # read() returns a numpy array: (H, W, C) in BGR or BGRA
+        tile = self._czi.read(roi=roi, zoom=1.0 / downsample)
+
+        # Resize if the returned shape doesn't exactly match (can happen at edges)
+        if tile.shape[:2] != (h, w):
+            tile = np.array(Image.fromarray(tile).resize((w, h)))
+
+        # data is BGR, convert to RGB
+        tile = np.stack([tile[:, :, 2], tile[:, :, 1], tile[:, :, 0]], -1)
+
+        return tile
+
+    def get_thumbnail(self, size: tuple) -> np.ndarray:
+        """
+        Return a thumbnail of the whole slide.
+        """
+        w, h = self.level_dimensions[0]
+        thumb_w, thumb_h = size
+        zoom = min(thumb_w / w, thumb_h / h)
+        return self._czi.read(zoom=zoom)
+
+    def get_best_level_for_downsample(self, downsample: float) -> int:
+        """
+        Get the best level for a given downsample factor.
+
+        Args:
+            downsample (float): Downsample factor.
+
+        Returns:
+            int: Best level.
+        """
+        for i, ds in enumerate(self.level_downsamples):
+            if downsample < ds:
+                return i
+        return i
+
+    def close(self):
+        self._czi.close()
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *args):
+        self.close()
+
+
+WSI_READERS = {
+    "czi-zeiss": CZISlide,
+    "openslide": OpenSlide,
+}
+
+
+def get_wsi_reader(reader_str: str) -> CZISlide:
+    """
+    Get a WSI reader for the given path.
+
+    Args:
+        reader_str (str): path to the WSI file.
+
+    Returns:
+        CZISlide: WSI reader.
+    """
+    if reader_str not in WSI_READERS:
+        readers = list(WSI_READERS.keys())
+        err = f"Reader {reader_str} not supported. "
+        err += f"Should be one of {readers}"
+        logger.error(err)
+        raise ValueError(err)
+    return WSI_READERS[reader_str]
+
+
+def WSIReader(*args, **kwargs):
+    reader_str = os.environ.get("WSI_READER", "openslide")
+    return get_wsi_reader(reader_str)(*args, **kwargs)

--- a/src/classpose/wsi_utils.py
+++ b/src/classpose/wsi_utils.py
@@ -33,23 +33,22 @@ class CZISlide:
         logger.info(f"MPP X: {mpp_x}, MPP Y: {mpp_y}")
 
         # Build level dimensions (scene 0, channel 0 by default)
-        stats = self._czi._czi_reader.GetSubBlockStats()
-        bb0 = stats.boundingBoxLayer0Only
-        bb0 = {
-            "x": bb0.x,
-            "y": bb0.y,
-            "w": bb0.w,
-            "h": bb0.h,
+        bbp = self._czi.total_bounding_box_no_pyramid
+        bbp = {
+            "x": bbp["X"][0],
+            "y": bbp["Y"][0],
+            "w": bbp["X"][1] - bbp["X"][0],
+            "h": bbp["Y"][1] - bbp["Y"][0],
         }
         bb = self._czi.total_bounding_box
         bounding_rect = self._czi.scenes_bounding_rectangle[0]
         logger.info(f"Total bounding box: {bb}")
         logger.info(f"Scenes bounding rectangle: {bounding_rect}")
-        logger.info(f"Bounding box (layer 0): {bb0}")
-        self._x_min = bb0["x"]
-        self._y_min = bb0["y"]
-        w = bb0["w"]
-        h = bb0["h"]
+        logger.info(f"Bounding box (layer 0): {bbp}")
+        self._x_min = bbp["x"]
+        self._y_min = bbp["y"]
+        w = bbp["w"]
+        h = bbp["h"]
 
         self.level_downsamples = [1, 2, 4, 8, 16]
         self.level_dimensions = [

--- a/tests/test_czi_reader.py
+++ b/tests/test_czi_reader.py
@@ -3,6 +3,8 @@ import pytest
 from pathlib import Path
 
 from classpose.utils import download_if_unavailable
+
+pytest.importorskip("pylibCZIrw")
 from classpose.wsi_utils import CZISlide
 
 

--- a/tests/test_czi_reader.py
+++ b/tests/test_czi_reader.py
@@ -1,0 +1,52 @@
+import numpy as np
+import pytest
+from pathlib import Path
+
+from classpose.utils import download_if_unavailable
+from classpose.wsi_utils import CZISlide
+
+
+@pytest.fixture
+def test_data_dir():
+    path = Path("tests/data")
+    path.mkdir(parents=True, exist_ok=True)
+    return path
+
+
+@pytest.fixture
+def zeiss_czi(test_data_dir):
+    path = test_data_dir / "Zeiss-5-Cropped.czi"
+    url = "https://openslide.cs.cmu.edu/download/openslide-testdata/Zeiss/Zeiss-5-Cropped.czi"
+    download_if_unavailable(str(path), url)
+    return path
+
+
+def test_czi_slide_properties_and_levels(zeiss_czi):
+    with CZISlide(str(zeiss_czi)) as slide:
+        assert slide.level_count == 5
+        assert slide.level_downsamples == [1, 2, 4, 8, 16]
+        assert slide.level_dimensions[0][0] > 0
+        assert slide.level_dimensions[0][1] > 0
+        assert slide.properties["openslide.vendor"] == "zeiss"
+        assert slide.properties["openslide.mpp-x"] > 0
+        assert slide.properties["openslide.mpp-y"] > 0
+
+
+def test_czi_slide_read_region(zeiss_czi):
+    with CZISlide(str(zeiss_czi)) as slide:
+        tile = slide.read_region((0, 0), level=0, size=(256, 128))
+
+    assert isinstance(tile, np.ndarray)
+    assert tile.shape == (128, 256, 3)
+    assert tile.dtype == np.uint8
+
+
+def test_czi_slide_thumbnail(zeiss_czi):
+    with CZISlide(str(zeiss_czi)) as slide:
+        thumb = slide.get_thumbnail((256, 256))
+
+    assert isinstance(thumb, np.ndarray)
+    assert thumb.ndim == 3
+    assert thumb.shape[0] > 0
+    assert thumb.shape[1] > 0
+    assert thumb.shape[2] >= 3

--- a/tests/test_grandqc_integration.py
+++ b/tests/test_grandqc_integration.py
@@ -1,10 +1,10 @@
-import os
 import pytest
 import numpy as np
 from pathlib import Path
 from openslide import OpenSlide
 from classpose.grandqc.wsi_tissue_detection import detect_tissue_wsi
 from classpose.grandqc.wsi_artefact_detection import detect_artefacts_wsi
+from classpose import WSIReader
 from classpose.utils import download_if_unavailable
 
 
@@ -19,6 +19,14 @@ def test_data_dir():
 def jp2k_33005_svs(test_data_dir):
     path = test_data_dir / "CMU-1-JP2K-33005.svs"
     url = "https://openslide.cs.cmu.edu/download/openslide-testdata/Aperio/CMU-1-JP2K-33005.svs"
+    download_if_unavailable(str(path), url)
+    return path
+
+
+@pytest.fixture
+def zeiss_czi(test_data_dir):
+    path = test_data_dir / "Zeiss-5-Cropped.czi"
+    url = "https://openslide.cs.cmu.edu/download/openslide-testdata/Zeiss/Zeiss-5-Cropped.czi"
     download_if_unavailable(str(path), url)
     return path
 
@@ -63,6 +71,49 @@ def test_artefact_detection_integration(jp2k_33005_svs, output_dir):
     slide = OpenSlide(str(jp2k_33005_svs))
 
     # Run artefact detection
+    results = detect_artefacts_wsi(slide=slide, device="cuda", min_area=100)
+
+    artefact_mask, artefact_map, artefact_cnts, geojson = results
+
+    assert isinstance(artefact_mask, np.ndarray)
+    assert isinstance(artefact_map, np.ndarray)
+    assert isinstance(artefact_cnts, dict)
+    assert geojson["type"] == "FeatureCollection"
+
+
+def test_tissue_detection_czi_integration(zeiss_czi, output_dir, monkeypatch):
+    """
+    Test GrandQC tissue detection with Zeiss-5-Cropped.czi using CZISlide reader.
+    """
+    assert zeiss_czi.exists(), f"Test slide {zeiss_czi} not found"
+
+    monkeypatch.setenv("WSI_READER", "czi-zeiss")
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    slide = WSIReader(str(zeiss_czi))
+
+    results = detect_tissue_wsi(slide=slide, device="cpu", min_area=100)
+
+    image, mask, filled_class_map, output_cnts, geojson, mpp = results
+
+    assert image is not None
+    assert isinstance(mask, np.ndarray)
+    assert len(output_cnts) >= 0
+    assert geojson["type"] == "FeatureCollection"
+    assert mpp > 0
+
+
+def test_artefact_detection_czi_integration(zeiss_czi, output_dir, monkeypatch):
+    """
+    Test GrandQC artefact detection with Zeiss-5-Cropped.czi using CZISlide reader.
+    """
+    assert zeiss_czi.exists()
+
+    monkeypatch.setenv("WSI_READER", "czi-zeiss")
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    slide = WSIReader(str(zeiss_czi))
+
     results = detect_artefacts_wsi(slide=slide, device="cuda", min_area=100)
 
     artefact_mask, artefact_map, artefact_cnts, geojson = results

--- a/tests/test_prediction_integration.py
+++ b/tests/test_prediction_integration.py
@@ -76,7 +76,6 @@ def test_predict_wsi_integration(small_region_svs, output_dir):
     basename = small_region_svs.stem
     assert (output_dir / f"{basename}_cell_contours.geojson").exists()
     assert (output_dir / f"{basename}_cell_centroids.geojson").exists()
-
     with open(output_dir / f"{basename}_cell_contours.geojson") as f:
         data = json.load(f)
         assert data["type"] == "FeatureCollection"

--- a/uv.lock
+++ b/uv.lock
@@ -514,6 +514,9 @@ dependencies = [
 ]
 
 [package.optional-dependencies]
+czi-zeiss = [
+    { name = "pylibczirw" },
+]
 notebook = [
     { name = "jupyter" },
     { name = "matplotlib" },
@@ -546,6 +549,7 @@ requires-dist = [
     { name = "pandas", specifier = "<3.0.0" },
     { name = "pre-commit", specifier = ">=4.3.0" },
     { name = "pydantic", specifier = ">=2.11.9" },
+    { name = "pylibczirw", marker = "extra == 'czi-zeiss'", specifier = ">=5.1.1" },
     { name = "pyyaml", specifier = ">=6.0.2" },
     { name = "scikit-image", specifier = ">=0.25.2" },
     { name = "scikit-learn", specifier = ">=1.6.1" },
@@ -561,7 +565,7 @@ requires-dist = [
     { name = "tqdm", specifier = ">=4.67.1" },
     { name = "zarr", specifier = ">=3.1.5" },
 ]
-provides-extras = ["notebook"]
+provides-extras = ["notebook", "czi-zeiss"]
 
 [package.metadata.requires-dev]
 dev = [{ name = "pytest", specifier = ">=9.0.2" }]
@@ -585,6 +589,32 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/27/fb/576f067976d320f5f0114a8d9fa1215425441bb35627b1993e5afd8111e5/cloudpickle-3.1.2.tar.gz", hash = "sha256:7fda9eb655c9c230dab534f1983763de5835249750e85fbcef43aaa30a9a2414", size = 22330, upload-time = "2025-11-03T09:25:26.604Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/88/39/799be3f2f0f38cc727ee3b4f1445fe6d5e4133064ec2e4115069418a5bb6/cloudpickle-3.1.2-py3-none-any.whl", hash = "sha256:9acb47f6afd73f60dc1df93bb801b472f05ff42fa6c84167d25cb206be1fbf4a", size = 22228, upload-time = "2025-11-03T09:25:25.534Z" },
+]
+
+[[package]]
+name = "cmake"
+version = "4.2.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/3d/1d/f917d89175a54938837f44f7672bc2bc24d1f6fc85c7f787b8d29c1017d2/cmake-4.2.3.tar.gz", hash = "sha256:7a6bc333453c9f7614c7a6e664950d309a5e1f89fa98512d537d4fde27eb8fae", size = 36957, upload-time = "2026-02-28T17:49:18.848Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/80/5f/965d2caf7b05e15853974eb36cdc3a8029c09bac886f7448d3f6ad4a8c5d/cmake-4.2.3-py3-none-macosx_10_10_universal2.whl", hash = "sha256:8604578dd087631b1c829315e78e6c81d9549708df2085c89722d5be6174a71f", size = 51591021, upload-time = "2026-02-28T17:48:21.225Z" },
+    { url = "https://files.pythonhosted.org/packages/29/92/c8895ffc12c5241111282340c56450707dd8d2f8d1f26c715087e21e3b01/cmake-4.2.3-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:a7e63d254ef3df90299779f5b41bf84cef02fa864255c567356089ea7c382c65", size = 29007127, upload-time = "2026-02-28T17:48:24.701Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/2f/f8438b417275d993d457d99f031fbc104bdda879ec7bdf3c6a78b8af05f7/cmake-4.2.3-py3-none-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:56e88a69c95e6defafc8e68ba8b99ca9c4dd6e4c97e7f8039283fe263f1de3c9", size = 30064565, upload-time = "2026-02-28T17:48:27.705Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/c5/6a2e1b69d58422ddb6370e5d1e5574218dafe200c61a96add1c4cbe5640e/cmake-4.2.3-py3-none-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:b243937103331a27e8fae4b9a72b4a852c281fb1339e76eef9e9915d4536c7c9", size = 29837850, upload-time = "2026-02-28T17:48:30.749Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/1c/9445c89cfcfbafe1c61a6a1c38072ddcb8413397a736db3bbe8c01f015cc/cmake-4.2.3-py3-none-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:c53c2a314a3723f0653c0f90aacca68267f0db003ca596bb2aa65e7fdafa31e2", size = 27749297, upload-time = "2026-02-28T17:48:36.717Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/c2/7ecd2aec927262ff2898d371f44ccb15884b6172407326e9388df07f9642/cmake-4.2.3-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:8e91b381aaea3c47110583dccc52f4562333d1accdbb806939f953c16e74ec0a", size = 28904315, upload-time = "2026-02-28T17:48:39.835Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/10/b41652c2ce1a33102386f6d65c22192284ed780de2d8ab3f416d795d928b/cmake-4.2.3-py3-none-manylinux_2_31_armv7l.whl", hash = "sha256:76eae39cd8855e80a2b485686f3539c39cba5c7eae49c4b634a15638d4edf39f", size = 26086034, upload-time = "2026-02-28T17:48:42.696Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/2e/d69fd449414b5bdc551ede33e8ba41fd293458865bf9d4d6745fe8fe4e5a/cmake-4.2.3-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:e3dfbaeffac5848dce60b62a93eecd96b7a3eb0af6d874efc4ec0edb72ec7a24", size = 26203962, upload-time = "2026-02-28T17:48:45.897Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/cd/6b703e911069bc9d099097bf9d1cf5f61b627913c1dace890718484218c9/cmake-4.2.3-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:3a21c36a64f52737e37dbeda0ce76391156139d546d995ed0992c3d4bc306636", size = 37881542, upload-time = "2026-02-28T17:48:48.843Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/15/4949cb479231bd6dcf204ffff4b5775c2a471754e73b8f9365ba17a6aa49/cmake-4.2.3-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:66dff80bc6c955592861f662abebc50ddc4d097bfd1630d496559f7e7017e769", size = 34523393, upload-time = "2026-02-28T17:48:51.55Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/39/9c5071dfe0774ad442dab753716e472b537da0bf3fefbc61362ab60b7e5e/cmake-4.2.3-py3-none-musllinux_1_2_i686.whl", hash = "sha256:2605260fa17826c138ad3d78cdc3c6250b860f6c957653e35208c11e2ca4ad91", size = 40419861, upload-time = "2026-02-28T17:48:54.946Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/bd/44655063228db7d8f69f8ce3f84d44b854ab2a9bdc530fd9280e64377811/cmake-4.2.3-py3-none-musllinux_1_2_ppc64le.whl", hash = "sha256:f3693c97daaeedc931c6c2ef67b7213e60ef8e51c11050b6a7f4628f5f2a7883", size = 39615316, upload-time = "2026-02-28T17:48:58.308Z" },
+    { url = "https://files.pythonhosted.org/packages/28/e4/f4ae13e3162151cdf978d9b279b6f21dd4b358bcc938607f7bddfd1f1da3/cmake-4.2.3-py3-none-musllinux_1_2_riscv64.whl", hash = "sha256:849ce056d644e1c84ba835976e8adc9777ccd2078d81ca80c20a933e4711b3f7", size = 34768312, upload-time = "2026-02-28T17:49:01.787Z" },
+    { url = "https://files.pythonhosted.org/packages/28/5e/32ffc26ca34400de8c7fa5b03f3c132636268cb83f79b6a2f8c7dd8dc923/cmake-4.2.3-py3-none-musllinux_1_2_s390x.whl", hash = "sha256:1432016bf6cb533ff8833e0a434c640aa097ffd1a5c0e9341554c2c146050363", size = 36812265, upload-time = "2026-02-28T17:49:04.873Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/71/8324902abe3e883bc1d9adfb3c3e602e87f485b797defc87d0fe15fbb109/cmake-4.2.3-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:22c85da6d4aacebb3ed649bb7dc2fc034c6744f25ed8a02537408fe3c914bf9e", size = 37795828, upload-time = "2026-02-28T17:49:08.142Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/df/1b7d450ea66ba054c653165beab71414ccc1c1ea056e51574ae75206ea91/cmake-4.2.3-py3-none-win32.whl", hash = "sha256:2091e4c1b45e6e900dda4aebce1d3e912ddc3ba0c153dd6b35be0b18f7f2b2ce", size = 35499316, upload-time = "2026-02-28T17:49:10.957Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/d9/f1693ab5e403ae010df8c7ec12c77b2671080ec5c158b37f8db78814be96/cmake-4.2.3-py3-none-win_amd64.whl", hash = "sha256:0c55af0e1b2db232a94a7c34e89f25f3dbf410a4669b11134d07de0bd7aad03e", size = 38891890, upload-time = "2026-02-28T17:49:13.757Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/4b/6b246acb4be50867dc9237d55a0bc1ec0c8fbd47db2c868f1f2b4b690e76/cmake-4.2.3-py3-none-win_arm64.whl", hash = "sha256:e9d3761edc558b89321283c258f3bc036d2cda4c22ecfa181a25bb84e96afd4a", size = 38005743, upload-time = "2026-02-28T17:49:16.563Z" },
 ]
 
 [[package]]
@@ -3115,6 +3145,26 @@ wheels = [
 ]
 
 [[package]]
+name = "pylibczirw"
+version = "5.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cmake" },
+    { name = "numpy" },
+    { name = "packaging" },
+    { name = "validators" },
+    { name = "xmltodict" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/46/15/b76a1891fe45483b4088e25e11e28bb6e2477194414d8987a7f648595898/pylibczirw-5.1.1.tar.gz", hash = "sha256:d10e81a83ebaebd704a0a1e2932a4dbc2b20f1f308f13661fb36d28d03caf114", size = 5910292, upload-time = "2025-10-23T09:00:30.679Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6b/4d/b0662c259925942c5f940d1f522fba37d9ea3a9c8769070b3ed3d24bf87a/pylibczirw-5.1.1-cp313-cp313-macosx_10_15_x86_64.whl", hash = "sha256:fe8128e3b54262d61cb0c5a346146d7a52bc9143c95d83dc872f0fee315135ce", size = 1179685, upload-time = "2025-10-23T09:00:15.329Z" },
+    { url = "https://files.pythonhosted.org/packages/18/0a/f4f676587d0d5d0d528fd728dd0cec64000e7b0a31f915f8ffda886d7e49/pylibczirw-5.1.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:f9adfbd6c172776cc419fa167379c44c914544d67647bf871f5d63656170857c", size = 1001478, upload-time = "2025-10-23T09:00:16.9Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/12/37c55cc779709b7ad809245c4c87f0785a14b8cc620ae91ceee3c7202c87/pylibczirw-5.1.1-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5ce26438c33c30bbe8ba98966ea71dc69d430aeeaf381692af029fa4b31e2ce5", size = 4515609, upload-time = "2025-10-23T09:00:18.196Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/b3/82852e2d298d09ed94a56affccd602169882f5ebd0b866895e36d9cd7800/pylibczirw-5.1.1-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5f5392637029b0d2e44597e7aaf56d5702741f72f2b2cf29f9a240975f44fa0c", size = 4266407, upload-time = "2025-10-23T09:00:19.835Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/d3/18d73a051ddc14d2eedf6e577462df7c13a23c5696b3b0c312b48d62ae3b/pylibczirw-5.1.1-cp313-cp313-win_amd64.whl", hash = "sha256:e6c9c621f23f3433839b4c02500a4f5a7216d4ba31a674bc278a77a68e5eaaf1", size = 1291621, upload-time = "2025-10-23T09:00:22.045Z" },
+]
+
+[[package]]
 name = "pynndescent"
 version = "0.6.0"
 source = { registry = "https://pypi.org/simple" }
@@ -4324,6 +4374,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/c7/24/5f1b3bdffd70275f6661c76461e25f024d5a38a46f04aaca912426a2b1d3/urllib3-2.6.3.tar.gz", hash = "sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed", size = 435556, upload-time = "2026-01-07T16:24:43.925Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/39/08/aaaad47bc4e9dc8c725e68f9d04865dbcb2052843ff09c97b08904852d84/urllib3-2.6.3-py3-none-any.whl", hash = "sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4", size = 131584, upload-time = "2026-01-07T16:24:42.685Z" },
+]
+
+[[package]]
+name = "validators"
+version = "0.35.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/66/a435d9ae49850b2f071f7ebd8119dd4e84872b01630d6736761e6e7fd847/validators-0.35.0.tar.gz", hash = "sha256:992d6c48a4e77c81f1b4daba10d16c3a9bb0dbb79b3a19ea847ff0928e70497a", size = 73399, upload-time = "2025-05-01T05:42:06.7Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fa/6e/3e955517e22cbdd565f2f8b2e73d52528b14b8bcfdb04f62466b071de847/validators-0.35.0-py3-none-any.whl", hash = "sha256:e8c947097eae7892cb3d26868d637f79f47b4a0554bc6b80065dfe5aac3705dd", size = 44712, upload-time = "2025-05-01T05:42:04.203Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
This PR:

1. Implements an interface identical to that of `OpenSlide` to read .czi (Zeiss) images (`CZISlide`). This features i) the `read_region` method, ii) slide properties (i.e. `openslide.vendor`, `openslide.mpp-x`, `openslide.mpp-y`, `openslide.bounds-x`, `openslide.bounds-y`, `openslide.real-bounds-x`, `openslide.real-bounds-y`), and the iii) `get_thumbnail` and `get_best_level_for_downsample` methods. Importantly, `openslide.bounds-x` and `openslide.bounds-y` are always set to 0 because this class handles the CZI file bounding box natively
2. Adds this as optional dependency, which required creating some interfaces (`WSIReader`) to avoid exposing `CZISlide` unless the optional dependencies (`--optional czi-zeiss`) are flagged
3. Triggering this requires setting the environment variable `WSI_READER` as `czi-zeiss`. Otherwise, Classpose will simply use the standard OpenSlide backend for WSI reading and processing
4. Adds tests which test CZI functionalities and integration for GrandQC-based workflows

This is an important addition as it allows us to process more datases without resorting to complicated intermediate file format conversions, and it stands - to the best of my knowledge - as the first implementation of a simple interface for JPEG XR compressed .czi files.