### PR TITLE
Makes polygons valid when loading ROI contours

### DIFF
--- a/src/classpose/entrypoints/predict_wsi.py
+++ b/src/classpose/entrypoints/predict_wsi.py
@@ -844,7 +844,7 @@ def shapely_polygon_to_geojson(
 
 def make_valid(
     polygon: shapely.Polygon | shapely.MultiPolygon | shapely.Geometry,
-) -> shapely.Polygon | shapely.MultiPolygon:
+) -> shapely.Polygon | shapely.MultiPolygon | shapely.GeometryCollection:
     """
     Makes a polygon valid and returns either a polygon or a multi-polygon,
     both ready for use in downstream functions.
@@ -854,12 +854,12 @@ def make_valid(
             polygon to make valid.
 
     Returns:
-        shapely.Polygon | shapely.MultiPolygon: The valid polygon.
+        shapely.Polygon | shapely.MultiPolygon | shapely.GeometryCollection: The valid polygon.
     """
     if isinstance(polygon, shapely.Polygon):
         if polygon.is_valid:
             return polygon
-        return shapely.make_valid(polygon)
+        return shapely.make_valid(polygon, method="structure")
 
     if isinstance(polygon, shapely.MultiPolygon):
         geoms = []
@@ -869,9 +869,13 @@ def make_valid(
                 geoms.extend(geom.geoms)
             else:
                 geoms.append(geom)
+        if not geoms:
+            return shapely.MultiPolygon([])
+        if len(geoms) == 1:
+            return geoms[0]
         return shapely.MultiPolygon(geoms)
 
-    return shapely.make_valid(polygon)
+    return shapely.make_valid(polygon, method="structure")
 
 
 def load_roi_polygons(

--- a/src/classpose/entrypoints/predict_wsi.py
+++ b/src/classpose/entrypoints/predict_wsi.py
@@ -869,7 +869,7 @@ def make_valid(
                 geoms.extend(geom.geoms)
             else:
                 geoms.append(geom)
-        return shapely.make_valid(polygon)
+        return shapely.MultiPolygon(polygon)
 
     return shapely.make_valid(polygon)
 

--- a/src/classpose/entrypoints/predict_wsi.py
+++ b/src/classpose/entrypoints/predict_wsi.py
@@ -869,7 +869,7 @@ def make_valid(
                 geoms.extend(geom.geoms)
             else:
                 geoms.append(geom)
-        return shapely.MultiPolygon(polygon)
+        return shapely.MultiPolygon(geoms)
 
     return shapely.make_valid(polygon)
 

--- a/src/classpose/entrypoints/predict_wsi.py
+++ b/src/classpose/entrypoints/predict_wsi.py
@@ -260,7 +260,7 @@ class SlideLoader:
             )
             self.tissue_cnts.extend(
                 [
-                    shapely.Polygon(cnt["contour"], cnt["holes"])
+                    make_valid(shapely.Polygon(cnt["contour"], cnt["holes"]))
                     for cnt in tissue_cnts.values()
                 ]
             )

--- a/src/classpose/entrypoints/predict_wsi.py
+++ b/src/classpose/entrypoints/predict_wsi.py
@@ -350,6 +350,18 @@ class SlideLoader:
             ]
         )
 
+    def _check_tile_in_cnts(
+        self,
+        coords: tuple[int, int],
+        tile_size: int,
+        cnts: list[shapely.Geometry],
+    ):
+        tile = self._point_to_square_polygon(coords, tile_size)
+        has_roi = any([cnt.intersects(tile) for cnt in cnts])
+        if not has_roi:
+            return False
+        return True
+
     def fill_queue(self):
         """
         Fills the queue with tiles for inference.
@@ -368,18 +380,14 @@ class SlideLoader:
         with tqdm(self.coords, desc="Tiles to predict: 0", position=0) as pbar:
             for coords, tile_size in pbar:
                 if self.tissue_cnts:
-                    tile = self._point_to_square_polygon(coords, tile_size)
-                    has_tissue = any(
-                        [cnt.intersects(tile) for cnt in self.tissue_cnts]
-                    )
-                    if not has_tissue:
+                    if not self._check_tile_in_cnts(
+                        coords, tile_size, self.tissue_cnts
+                    ):
                         continue
                 if self.roi_cnts:
-                    tile = self._point_to_square_polygon(coords, tile_size)
-                    has_roi = any(
-                        [cnt.intersects(tile) for cnt in self.roi_cnts]
-                    )
-                    if not has_roi:
+                    if not self._check_tile_in_cnts(
+                        coords, tile_size, self.roi_cnts
+                    ):
                         continue
                 tile = self.slide.read_region(
                     coords, self.level, (tile_size, tile_size)
@@ -834,6 +842,38 @@ def shapely_polygon_to_geojson(
     ]
 
 
+def make_valid(
+    polygon: shapely.Polygon | shapely.MultiPolygon | shapely.Geometry,
+) -> shapely.Polygon | shapely.MultiPolygon:
+    """
+    Makes a polygon valid and returns either a polygon or a multi-polygon,
+    both ready for use in downstream functions.
+
+    Args:
+        polygon (shapely.Polygon | shapely.MultiPolygon | shapely.Geometry): The
+            polygon to make valid.
+
+    Returns:
+        shapely.Polygon | shapely.MultiPolygon: The valid polygon.
+    """
+    if isinstance(polygon, shapely.Polygon):
+        if polygon.is_valid:
+            return polygon
+        return shapely.make_valid(polygon)
+
+    if isinstance(polygon, shapely.MultiPolygon):
+        geoms = []
+        for geom in polygon.geoms:
+            geom = make_valid(geom)
+            if isinstance(geom, shapely.MultiPolygon):
+                geoms.extend(geom.geoms)
+            else:
+                geoms.append(geom)
+        return shapely.make_valid(polygon)
+
+    return shapely.make_valid(polygon)
+
+
 def load_roi_polygons(
     roi_geojson_path: str, group_by_class: bool = False
 ) -> (
@@ -865,6 +905,7 @@ def load_roi_polygons(
         if not geom:
             continue
         shp = shapely.geometry.shape(geom)
+        shp = make_valid(shp)
 
         class_name = None
         if group_by_class:

--- a/tests/test_polygon_handling.py
+++ b/tests/test_polygon_handling.py
@@ -1,0 +1,41 @@
+import pytest
+import shapely
+from classpose.entrypoints.predict_wsi import make_valid, get_maximum_lengths
+
+polygon = {
+    "type": "MultiPolygon",
+    "coordinates": [
+        [
+            [
+                [9520, 14217],
+                [12017, 17987],
+                [14620.19, 15975.51],
+                [13087, 11312],
+                [9520, 14217],
+                [14620.19, 15975.51],
+                [15533, 18752],
+                [15992, 16968],
+                [15735.36, 15113.82],
+                [14620.19, 15975.51],
+                [15329, 12178],
+                [15735.36, 15113.82],
+                [17622, 13656],
+                [15329, 12178],
+            ]
+        ],
+    ],
+}
+
+
+@pytest.fixture
+def invalid_polygon_shapely():
+    return shapely.geometry.shape(polygon)
+
+
+def test_get_maximum_lengths_error(invalid_polygon_shapely):
+    with pytest.raises(shapely.errors.GEOSException):
+        get_maximum_lengths(invalid_polygon_shapely)
+
+
+def test_get_maximum_lengths_make_valid(invalid_polygon_shapely):
+    get_maximum_lengths(make_valid(invalid_polygon_shapely))


### PR DESCRIPTION
Self-explanatory. This adds a small function to make polygons valid and applies it to i) polygons being loaded from ROI contours and ii) tissue contours as predicted with the currently available method.