### PR TITLE
Remove border instances

### DIFF
--- a/paper_experiments/run_inference.py
+++ b/paper_experiments/run_inference.py
@@ -237,6 +237,7 @@ def main(args):
             match_iou=args.match_iou,
             nr_classes=n_classes - 1,
             n_workers=args.n_workers_metrics,
+            no_border_instances=args.no_border_instances,
         )
 
         if args.model_name is None:
@@ -359,6 +360,12 @@ if __name__ == "__main__":
         help="Training to inference MPP ratio."
         "If a single number, it will be used to rescale inference images before prediction."
         "If two colon-separated numbers are provided (i.e. 0.25:0.5), their ratio will be used.",
+    )
+    parser.add_argument(
+        "--no_border_instances",
+        action=argparse.BooleanOptionalAction,
+        default=False,
+        help="Whether to remove border instances during metrics computation.",
     )
 
     args = parser.parse_args()

--- a/paper_experiments/run_inference.py
+++ b/paper_experiments/run_inference.py
@@ -38,6 +38,19 @@ CLASS_COLORS = {
 
 
 def apply_class_colormap(class_mask, colors_dict):
+    """
+    Apply a class-to-colour mapping to a 2-D class mask.
+
+    Args:
+        class_mask (np.ndarray): 2-D integer array of shape ``(H, W)``
+            where each pixel value is a class ID.
+        colors_dict (dict[int, list[float]]): Mapping from class ID to
+            an RGB colour triplet (values in ``[0, 1]``).
+
+    Returns:
+        np.ndarray: Float32 RGB image of shape ``(H, W, 3)``.
+    """
+
     h, w = class_mask.shape
     colored_mask = np.zeros((h, w, 3), dtype=np.float32)
     for class_id, color_val in colors_dict.items():
@@ -68,7 +81,20 @@ def load_labels(labels_path: str) -> np.ndarray:
     return labels
 
 
-def get_rescale_ratio(training_to_inference_mpp: str):
+def get_rescale_ratio(training_to_inference_mpp: str) -> float:
+    """
+    Parse a rescale specification and return the spatial ratio.
+
+    The specification can be either a single float (used directly) or two
+    colon-separated floats ``"training_mpp:inference_mpp"`` whose ratio is
+    returned.
+
+    Args:
+        training_to_inference_mpp (str): Rescale specification string.
+
+    Returns:
+        float: Spatial ratio to rescale images by.
+    """
     ratio = 1.0
     if ":" in training_to_inference_mpp:
         training_mpp, inference_mpp = training_to_inference_mpp.split(":")
@@ -225,10 +251,10 @@ def main(args):
         )
 
         if args.ignore_classes:
-            for i in args.ignore_classes:
-                for i in range(len(pred_for_pq)):
-                    gt_for_pq[i][..., 1][gt_for_pq[i][..., 1] == i] = 0
-                    pred_for_pq[i][..., 1][pred_for_pq[i][..., 1] == i] = 0
+            for cls in args.ignore_classes:
+                for j in range(len(pred_for_pq)):
+                    gt_for_pq[j][..., 1][gt_for_pq[j][..., 1] == cls] = 0
+                    pred_for_pq[j][..., 1][pred_for_pq[j][..., 1] == cls] = 0
 
         logger.info("Running metrics computation.")
         global_metrics, per_image_metrics = compute_multiclass_pq_metrics(
@@ -363,7 +389,7 @@ if __name__ == "__main__":
     )
     parser.add_argument(
         "--no_border_instances",
-        action=argparse.BooleanOptionalAction,
+        action="store_true",
         default=False,
         help="Whether to remove border instances during metrics computation.",
     )

--- a/src/classpose/entrypoints/calculate_metrics.py
+++ b/src/classpose/entrypoints/calculate_metrics.py
@@ -37,6 +37,13 @@ from classpose.metrics.utils import load_masks
 
 
 def main(args):
+    """Load masks, apply optional label/class remapping, and compute PQ metrics.
+
+    Args:
+        args (argparse.Namespace): Parsed command-line arguments. See
+            :func:`main_with_args` for the full list of supported options.
+    """
+
     logger.info(f"Loading ground truth masks from {args.gt_path}")
     gt_masks = load_masks(args.gt_path)
 
@@ -95,6 +102,7 @@ def main(args):
             gt_masks,
             pred_masks,
             match_iou=args.match_iou,
+            no_border_instances=args.no_border_instances,
         )
 
         # Print results
@@ -143,6 +151,7 @@ def main(args):
 
 
 def main_with_args():
+    """Parse command-line arguments and run :func:`main`."""
     parser = argparse.ArgumentParser(
         description="Compute PQ (Panoptic Quality) metrics between ground truth and predicted masks."
     )
@@ -190,7 +199,7 @@ def main_with_args():
     )
     parser.add_argument(
         "--no_border_instances",
-        type=bool,
+        action="store_true",
         default=False,
         help="Whether to remove border instances for metrics computations.",
     )

--- a/src/classpose/entrypoints/calculate_metrics.py
+++ b/src/classpose/entrypoints/calculate_metrics.py
@@ -117,6 +117,7 @@ def main(args):
             match_iou=args.match_iou,
             nr_classes=nr_classes,
             n_workers=args.n_workers,
+            no_border_instances=args.no_border_instances,
         )
 
         # Print results
@@ -186,6 +187,12 @@ def main_with_args():
         default=None,
         help="Label map for mutli-class conversion. Should be a list of k=v index pairs."
         "Example: --label_map 0=0 1=1 2=2.",
+    )
+    parser.add_argument(
+        "--no_border_instances",
+        type=bool,
+        default=False,
+        help="Whether to remove border instances for metrics computations.",
     )
     parser.add_argument(
         "--n_workers",

--- a/src/classpose/metrics/pq.py
+++ b/src/classpose/metrics/pq.py
@@ -12,22 +12,50 @@ from classpose.metrics.utils import (
 
 
 class MulticlassPQCalculator:
-    def __init__(self, nr_classes: int, match_iou: float):
+
+    def __init__(
+        self,
+        nr_classes: int,
+        match_iou: float,
+        no_border_instances: bool = False,
+    ):
         self.nr_classes = nr_classes
         self.match_iou = match_iou
+        self.no_border_instances = no_border_instances
 
-    def __call__(self, gt_pred_idx):
+    def __call__(
+        self, gt_pred_idx: tuple[np.ndarray, np.ndarray, int]
+    ) -> tuple[list, int]:
         gt, pred, idx = gt_pred_idx
+        if self.no_border_instances:
+            gt = remove_border_instances(gt)
+            pred = remove_border_instances(pred)
         pq_info = get_multi_pq_info(
             gt, pred, nr_classes=self.nr_classes, match_iou=self.match_iou
         )
         return pq_info, idx
 
 
+def remove_border_instances(mask: np.ndarray) -> np.ndarray:
+    if len(mask.shape) == 3:
+        instances = mask[..., 0]
+    else:
+        instances = mask
+    border_instances = np.unique(
+        np.concatenate(
+            [instances[0], instances[:, 0], instances[-1], instances[:, -1]]
+        )
+    )
+    border_instances = border_instances[border_instances != 0]
+    mask[np.isin(instances, border_instances)] = 0
+    return masks
+
+
 def compute_binary_pq_metrics(
     gt_masks: np.ndarray | list[np.ndarray],
     pred_masks: np.ndarray | list[np.ndarray],
     match_iou: float = 0.5,
+    no_border_instances: bool = False,
 ) -> pd.DataFrame:
     """
     Compute binary PQ metrics for a batch of masks. Expects both input
@@ -37,6 +65,9 @@ def compute_binary_pq_metrics(
         gt_masks (np.ndarray | list[np.ndarray]): Ground truth masks.
         pred_masks (np.ndarray | list[np.ndarray]): Predicted masks.
         match_iou (float, optional): IoU threshold for matching. Defaults to 0.5.
+        no_border_instances (bool, optional): Whether to remove border instances.
+            These are defined as instances which have any pixel on the border.
+            Defaults to False.
 
     Returns:
         pd.DataFrame: DataFrame with PQ metrics.
@@ -50,6 +81,10 @@ def compute_binary_pq_metrics(
     for i in tqdm(range(len(gt_masks)), desc="Computing metrics"):
         gt = gt_masks[i]
         pred = pred_masks[i]
+
+        if no_border_instances:
+            gt = remove_border_instances(gt)
+            pred = remove_border_instances(pred)
 
         # Ensure masks have proper instance IDs (contiguous)
         gt = remap_label(gt)
@@ -86,6 +121,7 @@ def compute_multiclass_pq_metrics(
     match_iou: float = 0.5,
     nr_classes: int = 6,
     n_workers: int = 0,
+    no_border_instances: bool = False,
 ) -> pd.DataFrame | tuple[pd.DataFrame, pd.DataFrame]:
     """
     Compute multi-class PQ metrics for a batch of masks. Expects both input
@@ -98,6 +134,9 @@ def compute_multiclass_pq_metrics(
         match_iou (float, optional): IoU threshold for matching. Defaults to 0.5.
         nr_classes (int, optional): Number of classes. Defaults to 6.
         n_workers (int, optional): Number of workers for parallel processing. Defaults to 0.
+        no_border_instances (bool, optional): Whether to remove border instances.
+            These are defined as instances which have any pixel on the border.
+            Defaults to False.
 
     Returns:
         pd.DataFrame: DataFrame with global PQ metrics per class.
@@ -115,7 +154,9 @@ def compute_multiclass_pq_metrics(
 
     per_image_results = []
 
-    pq_calculator = MulticlassPQCalculator(nr_classes, match_iou)
+    pq_calculator = MulticlassPQCalculator(
+        nr_classes, match_iou, no_border_instances
+    )
 
     inputs_for_pq_calculator = zip(gt_masks, pred_masks, range(len(gt_masks)))
 

--- a/src/classpose/metrics/pq.py
+++ b/src/classpose/metrics/pq.py
@@ -12,6 +12,12 @@ from classpose.metrics.utils import (
 
 
 class MulticlassPQCalculator:
+    """
+    Callable that computes multi-class PQ info for a single image pair.
+
+    Designed to be used with :func:`multiprocessing.Pool.imap_unordered` so
+    that per-image PQ computation can be parallelised.
+    """
 
     def __init__(
         self,
@@ -19,6 +25,16 @@ class MulticlassPQCalculator:
         match_iou: float,
         no_border_instances: bool = False,
     ):
+        """
+        Initialise the calculator.
+
+        Args:
+            nr_classes (int): Number of foreground classes.
+            match_iou (float): IoU threshold for matching instances.
+            no_border_instances (bool, optional): If ``True``, instances
+                touching the image border are removed before metric
+                computation. Defaults to False.
+        """
         self.nr_classes = nr_classes
         self.match_iou = match_iou
         self.no_border_instances = no_border_instances
@@ -26,6 +42,16 @@ class MulticlassPQCalculator:
     def __call__(
         self, gt_pred_idx: tuple[np.ndarray, np.ndarray, int]
     ) -> tuple[list, int]:
+        """
+        Compute PQ info for one ground-truth / prediction pair.
+
+        Args:
+            gt_pred_idx (tuple[np.ndarray, np.ndarray, int]): A tuple of
+                ``(gt_mask, pred_mask, image_index)``.
+
+        Returns:
+            tuple[list, int]: Per-class PQ statistics and the image index.
+        """
         gt, pred, idx = gt_pred_idx
         if self.no_border_instances:
             gt = remove_border_instances(gt)
@@ -37,6 +63,21 @@ class MulticlassPQCalculator:
 
 
 def remove_border_instances(mask: np.ndarray) -> np.ndarray:
+    """
+    Zero-out instances that touch the image border.
+
+    An instance is considered a border instance if any of its pixels lie on
+    the first or last row/column of the mask.
+
+    Args:
+        mask (np.ndarray): Instance mask of shape ``(H, W)`` or
+            ``(H, W, C)``.  When 3-dimensional, the first channel is
+            treated as the instance channel and all channels are zeroed
+            for border instances.
+
+    Returns:
+        np.ndarray: Mask with border instances set to 0.
+    """
     if len(mask.shape) == 3:
         instances = mask[..., 0]
     else:
@@ -48,7 +89,7 @@ def remove_border_instances(mask: np.ndarray) -> np.ndarray:
     )
     border_instances = border_instances[border_instances != 0]
     mask[np.isin(instances, border_instances)] = 0
-    return masks
+    return mask
 
 
 def compute_binary_pq_metrics(

--- a/src/classpose/metrics/utils.py
+++ b/src/classpose/metrics/utils.py
@@ -9,7 +9,8 @@ from tqdm import trange
 
 
 def remap_label(arr):
-    """Renumbers labels to be contiguous. Just a wrapper around
+    """
+    Renumbers labels to be contiguous. Just a wrapper around
     fastremap.renumber.
 
     Args:
@@ -20,6 +21,7 @@ def remap_label(arr):
         arr (ndarray): Array with continguous ordering of instances.
 
     """
+
     return fastremap.renumber(arr.astype(np.int64))[0]
 
 

--- a/tests/test_remove_border_instances.py
+++ b/tests/test_remove_border_instances.py
@@ -1,0 +1,117 @@
+import numpy as np
+import pytest
+
+from classpose.metrics.pq import remove_border_instances
+
+
+def _make_instance_mask():
+    """
+    Create a 6x6 instance-only mask (H, W) with 4 instances.
+
+    Layout (instance IDs):
+        - Instance 1: top-left 3x3 block  → touches top and left borders
+        - Instance 2: top-right 3x3 block → touches top and right borders
+        - Instance 3: centre 2x2 block    → does NOT touch any border
+        - Instance 4: bottom-right 3x3 block → touches bottom and right borders
+    """
+    mask = np.zeros((6, 6), dtype=np.int64)
+    mask[0:3, 0:3] = 1
+    mask[0:3, 3:6] = 2
+    mask[2:4, 2:4] = 3
+    mask[3:6, 3:6] = 4
+    return mask
+
+
+class TestRemoveBorderInstancesInstanceOnly:
+    """
+    Tests for 2-D instance-only masks (H, W).
+    """
+
+    def test_border_instances_are_zeroed(self):
+        mask = _make_instance_mask()
+        result = remove_border_instances(mask)
+        # Instances 1, 2, 4 touch the border and should be removed
+        assert np.all(result[result != 0] == 3)
+
+    def test_interior_instance_is_preserved(self):
+        mask = _make_instance_mask()
+        result = remove_border_instances(mask)
+        expected_results = [
+            ([2, 2], 3),
+            ([2, 3], 3),
+            ([3, 2], 3),
+            ([3, 3], 0),
+        ]
+        for (x, y), r in expected_results:
+            assert result[x, y] == r
+
+    def test_all_border_returns_all_zeros(self):
+        """A mask where every instance touches the border."""
+        mask = np.zeros((4, 4), dtype=np.int64)
+        mask[0:2, :] = 1
+        mask[2:4, :] = 2
+        result = remove_border_instances(mask)
+        assert np.all(result == 0)
+
+    def test_empty_mask_is_unchanged(self):
+        mask = np.zeros((5, 5), dtype=np.int64)
+        result = remove_border_instances(mask)
+        assert np.all(result == 0)
+
+    def test_single_interior_instance(self):
+        mask = np.zeros((5, 5), dtype=np.int64)
+        mask[1:4, 1:4] = 7
+        result = remove_border_instances(mask)
+        assert np.all(result[1:4, 1:4] == 7)
+        assert result[0, :].sum() == 0
+        assert result[:, 0].sum() == 0
+
+
+class TestRemoveBorderInstancesWithClass:
+    """
+    Tests for 3-D masks (H, W, 2) with instance + class channels.
+    """
+
+    def _make_combined_mask(self):
+        """Build an (H, W, 2) mask from the instance layout."""
+        inst = _make_instance_mask()
+        cls = np.zeros_like(inst)
+        cls[inst == 1] = 1
+        cls[inst == 2] = 2
+        cls[inst == 3] = 3
+        cls[inst == 4] = 1
+        return np.stack([inst, cls], axis=-1)
+
+    def test_border_instances_zeroed_both_channels(self):
+        mask = self._make_combined_mask()
+        result = remove_border_instances(mask)
+        # Only instance 3 should survive in both channels
+        surviving_inst = np.unique(result[..., 0])
+        assert set(surviving_inst) == {0, 3}
+        surviving_cls = np.unique(result[..., 1])
+        assert set(surviving_cls) == {0, 3}
+
+    def test_interior_instance_class_preserved(self):
+        mask = self._make_combined_mask()
+        result = remove_border_instances(mask)
+        expected_results = [
+            ([2, 2, 0], 3),
+            ([2, 3, 0], 3),
+            ([3, 2, 0], 3),
+            ([3, 3, 0], 0),
+            ([2, 2, 1], 3),
+            ([2, 3, 1], 3),
+            ([3, 2, 1], 3),
+            ([3, 3, 1], 0),
+        ]
+        for (x, y, c), r in expected_results:
+            assert result[x, y, c] == r
+
+    def test_all_border_returns_all_zeros(self):
+        inst = np.zeros((4, 4), dtype=np.int64)
+        inst[0:2, :] = 1
+        inst[2:4, :] = 2
+        cls = np.ones_like(inst)
+        mask = np.stack([inst, cls], axis=-1)
+        result = remove_border_instances(mask)
+        assert np.all(result == 0)


### PR DESCRIPTION
Adds a small functionality to metrics calculation: removal of border instances using the `--no_border_instances` flag. Something similar is already available on Cellpose inference as [`--exclude-on-edges`](https://cellpose.readthedocs.io/en/latest/cli.html), here we make it available specifically for evaluation only.