### PR TITLE
Skip LineString polygons in shapely_polygon_to_geojson to prevent Attribute crash

### DIFF
--- a/src/classpose/entrypoints/predict_wsi.py
+++ b/src/classpose/entrypoints/predict_wsi.py
@@ -839,6 +839,8 @@ def shapely_polygon_to_geojson(
             )
         return features
 
+    if isinstance(polygon, shapely.LineString):
+        return []
     exterior = [list(pt) for pt in polygon.exterior.coords]
     interiors = [[list(pt) for pt in ring.coords] for ring in polygon.interiors]
     coordinates = [exterior, *interiors]


### PR DESCRIPTION
This PR adds an early return for LineString before the .exterior access, matching the existing skip logic.