### PR TITLE
Fixes some multiprocessing-related issues

### DIFF
--- a/src/classpose/entrypoints/predict_wsi.py
+++ b/src/classpose/entrypoints/predict_wsi.py
@@ -47,6 +47,7 @@ import uuid
 from pathlib import Path
 from multiprocessing.managers import SyncManager
 from multiprocessing import Event
+from multiprocessing.synchronize import Event as EventType
 
 import cv2
 import numpy as np
@@ -108,7 +109,7 @@ class SlideLoader:
         min_area: int = 0,
         roi_tree: shapely.STRtree | None = None,
         device: str | None = None,
-        termination_event: Event | None = None,
+        termination_event: EventType | None = None,
     ):
         """
         Args:

--- a/src/classpose/entrypoints/predict_wsi.py
+++ b/src/classpose/entrypoints/predict_wsi.py
@@ -514,14 +514,19 @@ class PostProcessor:
         self,
         manager: tmproc.Manager = None,
         n_workers: int = 1,
+        labels: list[str] | None = None,
     ):
         """
         Args:
             manager (tmproc.Manager, optional): Manager to use for shared memory.
             n_workers (int, optional): Number of inference workers that will send a None
                 sentinel when done. Defaults to 1.
+            labels (list[str], optional): List of class labels. If provided, enables
+                multi-class mode where data should be (masks, class_masks) tuples.
+                If None, single-class mode is used with default "cell" label.
         """
         self.n_workers = n_workers
+        self.labels = labels
 
         if manager is None:
             manager = tmproc.Manager()
@@ -560,7 +565,7 @@ class PostProcessor:
 
     def __call__(
         self,
-        data: list[tuple[np.ndarray, np.ndarray]],
+        data: list[tuple[np.ndarray, np.ndarray] | np.ndarray],
         batch_coords: list[tuple[int, int]],
         target_downsample: float,
     ):
@@ -569,13 +574,18 @@ class PostProcessor:
         to the polygons list, which is a shared memory list.
 
         Args:
-            data (list[tuple]): Data to process. Should be a list of tuples, where each
-                tuple contains masks and class_masks.
+            data (list[tuple | np.ndarray]): Data to process. For multi-class mode,
+                should be a list of (masks, class_masks) tuples. For single-class mode,
+                should be a list of masks arrays.
             batch_coords (list[tuple[int, int]]): List of coordinates for the batch.
             target_downsample (float): Level-0 pixels per prediction pixel.
         """
         for datum, coords in zip(data, batch_coords):
-            masks, class_masks = datum
+            if self.labels is not None:
+                masks, class_masks = datum
+            else:
+                masks = datum
+                class_masks = None
             u = np.unique(masks)
             u = u[u > 0]
             curr_cells = []
@@ -601,14 +611,24 @@ class PostProcessor:
                 center = np.round(polygon.centroid.coords[0], 2).tolist()
                 curr_coords = curr_coords.tolist()
                 curr_coords.append(curr_coords[0].copy())
-                cl = class_masks[cell_mask][0]
+
+                if class_masks is not None:
+                    cl = class_masks[cell_mask][0]
+                    label = self.labels[int(cl) - 1]
+                    color = COLORMAP[int(cl) - 1]
+                    class_int = int(cl) - 1
+                else:
+                    label = "cell"
+                    color = [0, 168, 132]
+                    class_int = 0
+
                 curr_cell = {
                     "id": str(uuid.uuid4()),
                     "coords": curr_coords,
-                    "class_int": int(cl) - 1,
+                    "class_int": class_int,
                     "area": polygon.area,
-                    "label": self.labels[int(cl) - 1],
-                    "color": COLORMAP[int(cl) - 1],
+                    "label": label,
+                    "color": color,
                     "perimeter": polygon.length,
                     "centroid": center,
                 }

--- a/src/classpose/entrypoints/predict_wsi.py
+++ b/src/classpose/entrypoints/predict_wsi.py
@@ -704,7 +704,6 @@ def worker(
             tile, coords = slide_queue.get()
             if tile is None:
                 break
-            tile = resize_tile_to_target_mpp(tile, resize_factor)
             masks, raw_data, class_masks, styles = model.eval(
                 [tile],
                 batch_size=batch_size,

--- a/src/classpose/entrypoints/predict_wsi.py
+++ b/src/classpose/entrypoints/predict_wsi.py
@@ -93,7 +93,9 @@ MIN_TILE_SIZE = 256
 COLORMAP = [[int(y * 255) for y in x] for x in colormaps["Set3"].colors]
 
 
-def resize_tile_to_target_mpp(tile: np.ndarray, resize_factor: float) -> np.ndarray:
+def resize_tile_to_target_mpp(
+    tile: np.ndarray, resize_factor: float
+) -> np.ndarray:
     """
     Resize a tile so that its apparent MPP matches the model MPP.
 
@@ -510,14 +512,11 @@ class PostProcessor:
 
     def __init__(
         self,
-        labels: list[str],
         manager: tmproc.Manager = None,
         n_workers: int = 1,
     ):
         """
         Args:
-            labels (list[str]): Ordered list of labels for the classes.
-                Background (0) should not be included.
             manager (tmproc.Manager, optional): Manager to use for shared memory.
             n_workers (int, optional): Number of inference workers that will send a None
                 sentinel when done. Defaults to 1.

--- a/src/classpose/entrypoints/predict_wsi.py
+++ b/src/classpose/entrypoints/predict_wsi.py
@@ -230,13 +230,15 @@ class SlideLoader:
         ):
             self._align_roi_tree_to_slide_bounds()
 
-        target_downsample = min(
+        prediction_to_slide_scale = min(
             self.train_mpp / self.mpp[0], self.train_mpp / self.mpp[1]
         )
-        self.level = self.slide.get_best_level_for_downsample(target_downsample)
+        self.level = self.slide.get_best_level_for_downsample(
+            prediction_to_slide_scale
+        )
         self.slide_dim = self.slide.level_dimensions[self.level]
         self.ts.value = self.slide.level_downsamples[self.level]
-        self.resize_factor.value = self.ts.value / target_downsample
+        self.resize_factor.value = self.ts.value / prediction_to_slide_scale
         read_tile_size = max(
             1, round(self.tile_size / self.resize_factor.value)
         )
@@ -259,12 +261,15 @@ class SlideLoader:
         logger.info(f"Slide dimensions: {self.slide_dim}")
         logger.info(f"Tile size: {self.tile_size}")
         logger.info(f"Overlap: {self.overlap}")
-        logger.info(f"Desired scale from MPP: {target_downsample}")
+        logger.info(
+            "Prediction-to-slide scale from MPP: %s",
+            prediction_to_slide_scale,
+        )
         logger.info(f"Selected level: {self.level}")
         logger.info(f"Selected level downsample: {self.ts.value}")
         logger.info(
             "Residual resize factor before inference: %s",
-            self.ts.value / target_downsample,
+            self.ts.value / prediction_to_slide_scale,
         )
 
     def _align_roi_tree_to_slide_bounds(self):
@@ -325,7 +330,7 @@ class SlideLoader:
             tile_size (int): Size of the tiles.
             overlap (int): Overlap between tiles.
             slide_dim (tuple[int, int]): Dimensions of the slide.
-            ts (float): Target downsample.
+            ts (float): Selected level downsample.
 
         Yields:
             tuple[int, int]: Tuple of coordinates (x, y).
@@ -367,7 +372,7 @@ class SlideLoader:
             tile_size (int): Size of the tiles.
             overlap (int): Overlap between tiles.
             slide_dim (tuple[int, int]): Dimensions of the slide.
-            ts (float): Target downsample.
+            ts (float): Selected level downsample.
 
         Yields:
             tuple[int, int]: Tuple of coordinates (x, y).
@@ -569,7 +574,7 @@ class PostProcessor:
         self,
         data: list[tuple[np.ndarray, np.ndarray] | np.ndarray],
         batch_coords: list[tuple[int, int]],
-        target_downsample: float,
+        prediction_to_slide_scale: float,
     ):
         """
         Data preprocessing following the aforementioned protocol. Appends everything
@@ -580,7 +585,7 @@ class PostProcessor:
                 should be a list of (masks, class_masks) tuples. For single-class mode,
                 should be a list of masks arrays.
             batch_coords (list[tuple[int, int]]): List of coordinates for the batch.
-            target_downsample (float): Level-0 pixels per prediction pixel.
+            prediction_to_slide_scale (float): Level-0 pixels per prediction pixel.
         """
         for datum, coords in zip(data, batch_coords):
             if self.labels is not None:
@@ -599,7 +604,7 @@ class PostProcessor:
                         cv2.RETR_EXTERNAL,
                         cv2.CHAIN_APPROX_SIMPLE,
                     )[0][0][:, 0]
-                    * target_downsample
+                    * prediction_to_slide_scale
                     + coords
                 )
                 # discard invalid polygons as these cannot be read in QuPath
@@ -655,7 +660,7 @@ def worker(
     n_invalid_cells: tmproc.Value,
     slide_downsample: float = 1,
     bsize: int = 256,
-    target_downsample: float = 1,
+    prediction_to_slide_scale: float = 1,
     bf16: bool = False,
 ):
     """
@@ -678,7 +683,7 @@ def worker(
         n_invalid_cells (tmproc.Value): tmp Value to count number of invalid cells.
         slide_downsample (float): Pyramid downsample used to read tiles.
         bsize (int): Batch size.
-        target_downsample (float): Level-0 pixels per prediction pixel.
+        prediction_to_slide_scale (float): Level-0 pixels per prediction pixel.
     """
     if isinstance(dev, str):
         dev = torch.device(dev)
@@ -717,7 +722,11 @@ def worker(
                     compute_masks=True,
                 )
                 postproc_queue.put(
-                    (list(zip(masks, class_masks)), [coords], target_downsample)
+                    (
+                        list(zip(masks, class_masks)),
+                        [coords],
+                        prediction_to_slide_scale,
+                    )
                 )
                 predicted_tiles.value += 1
 
@@ -1428,13 +1437,13 @@ def main(args):
     ts = float(slide.ts.value)
     mpp_x = float(slide.mpp_x.value)
     mpp_y = float(slide.mpp_y.value)
-    target_downsample = min(
+    prediction_to_slide_scale = min(
         model_config.mpp / mpp_x,
         model_config.mpp / mpp_y,
     )
     logger.info(
         "Prediction-to-slide coordinate scale: %s",
-        target_downsample,
+        prediction_to_slide_scale,
     )
 
     collected_batches: list = []
@@ -1471,7 +1480,7 @@ def main(args):
                     pp.n_invalid_cells,
                     ts,
                     256,
-                    target_downsample,
+                    prediction_to_slide_scale,
                     args.bf16,
                 ),
             )
@@ -1495,7 +1504,7 @@ def main(args):
             n_invalid_cells=pp.n_invalid_cells,
             slide_downsample=ts,
             bsize=256,
-            target_downsample=target_downsample,
+            prediction_to_slide_scale=prediction_to_slide_scale,
             bf16=args.bf16,
         )
 

--- a/src/classpose/entrypoints/predict_wsi.py
+++ b/src/classpose/entrypoints/predict_wsi.py
@@ -39,6 +39,7 @@ warnings.filterwarnings("ignore", message=".*Transforming to str index.*")
 
 import os
 import argparse
+import gc
 import json
 import logging
 import re
@@ -679,56 +680,65 @@ def worker(
         bsize (int): Batch size.
         target_downsample (float): Level-0 pixels per prediction pixel.
     """
-    model = ClassposeModel(
-        gpu=dev.type == "cuda",
-        pretrained_model=model_path,
-        device=dev,
-        nclasses=n_classes,
-        feature_transformation_structure=fts,
-    )
-    model.net.eval()
-    if bf16:
-        model.net = model.net.half()
     if isinstance(dev, str):
         dev = torch.device(dev)
-    if dev.type == "cuda":
-        model.net = torch.compile(model.net)
+    model = None
+    tile = masks = raw_data = class_masks = styles = None
 
-    with tqdm(
-        None,
-        desc="Predicted tiles (detected cells: 0)",
-        position=1,
-        total=0,
-    ) as pbar:
-        resize_factor = slide_downsample / target_downsample
-        while True:
-            tile, coords = slide_queue.get()
-            if tile is None:
-                break
-            masks, raw_data, class_masks, styles = model.eval(
-                [tile],
-                batch_size=batch_size,
-                augment=tta,
-                bsize=bsize,
-                compute_masks=True,
-            )
-            postproc_queue.put(
-                (list(zip(masks, class_masks)), [coords], target_downsample)
-            )
-            predicted_tiles.value += 1
+    try:
+        model = ClassposeModel(
+            gpu=dev.type == "cuda",
+            pretrained_model=model_path,
+            device=dev,
+            nclasses=n_classes,
+            feature_transformation_structure=fts,
+        )
+        model.net.eval()
+        if bf16:
+            model.net = model.net.half()
+        if dev.type == "cuda":
+            model.net = torch.compile(model.net)
 
-            pbar.n = predicted_tiles.value
-            pbar.total = slide_queue_size.value
+        with tqdm(
+            None,
+            desc="Predicted tiles (detected cells: 0)",
+            position=1,
+            total=0,
+        ) as pbar:
+            while True:
+                tile, coords = slide_queue.get()
+                if tile is None:
+                    break
+                masks, raw_data, class_masks, styles = model.eval(
+                    [tile],
+                    batch_size=batch_size,
+                    augment=tta,
+                    bsize=bsize,
+                    compute_masks=True,
+                )
+                postproc_queue.put(
+                    (list(zip(masks, class_masks)), [coords], target_downsample)
+                )
+                predicted_tiles.value += 1
+
+                pbar.n = predicted_tiles.value
+                pbar.total = slide_queue_size.value
+                pbar.set_description(
+                    f"Predicted tiles (detected cells: {n_cells.value}; invalid: {n_invalid_cells.value})"
+                )
+                pbar.refresh()
+
             pbar.set_description(
                 f"Predicted tiles (detected cells: {n_cells.value}; invalid: {n_invalid_cells.value})"
             )
-            pbar.refresh()
-
+            print()
+    finally:
+        tile = masks = raw_data = class_masks = styles = None
+        model = None
+        gc.collect()
+        if dev.type == "cuda":
+            torch.cuda.empty_cache()
         postproc_queue.put(None)
-        pbar.set_description(
-            f"Predicted tiles (detected cells: {n_cells.value}; invalid: {n_invalid_cells.value})"
-        )
-        print()
 
 
 def to_geojson_polygon(curr_cell: dict) -> dict:

--- a/src/classpose/entrypoints/predict_wsi.py
+++ b/src/classpose/entrypoints/predict_wsi.py
@@ -46,6 +46,7 @@ import time
 import uuid
 from pathlib import Path
 from multiprocessing.managers import SyncManager
+from multiprocessing import Event
 
 import cv2
 import numpy as np
@@ -107,6 +108,7 @@ class SlideLoader:
         min_area: int = 0,
         roi_tree: shapely.STRtree | None = None,
         device: str | None = None,
+        termination_event: Event | None = None,
     ):
         """
         Args:
@@ -126,6 +128,8 @@ class SlideLoader:
             roi_tree (shapely.STRtree, optional): STRtree of the ROI polygons.
                 Defaults to None.
             device (str, optional): Device to use for inference. Defaults to None.
+            termination_event (Event, optional): Event to signal termination.
+                Defaults to None.
         """
         self.slide_path = slide_path
         self.tile_size = tile_size
@@ -136,6 +140,7 @@ class SlideLoader:
         self.min_area = min_area
         self.roi_tree = roi_tree
         self.device = device
+        self.termination_event = termination_event
 
         self.downloaded_slide = None
 
@@ -402,6 +407,8 @@ class SlideLoader:
                 pbar.set_description(f"Tiles to predict: {n}")
         for _ in range(self.n_none):
             self.q.put((None, None))
+        if self.termination_event is not None:
+            self.termination_event.wait()
 
     def __iter__(self):
         """
@@ -420,6 +427,8 @@ class SlideLoader:
         """
         Closes the queue and joins the process.
         """
+        if self.termination_event is not None:
+            self.termination_event.set()
         self.p.join()
         if self.downloaded_slide is not None:
             logger.info(f"Removing downloaded slide {self.downloaded_slide}")
@@ -1238,6 +1247,7 @@ def filter_tile(tile: np.ndarray) -> bool:
 
 def main(args):
     tmproc.set_start_method("spawn", force=True)
+    termination_event = Event()
 
     if args.tile_size < MIN_TILE_SIZE:
         raise ValueError(
@@ -1296,6 +1306,7 @@ def main(args):
         min_area=args.min_area,
         roi_tree=roi_tree,
         device=devices[0],
+        termination_event=termination_event,
     )
     pp = PostProcessor(labels=labels, manager=manager)
     # Wait for slide to be initialized so that the target downsample is known

--- a/src/classpose/entrypoints/predict_wsi.py
+++ b/src/classpose/entrypoints/predict_wsi.py
@@ -380,7 +380,7 @@ class SlideLoader:
                 yield ((int(i * ts), int(j * ts)), tile_size)
 
     def _point_to_square_polygon(
-        self, point: tuple[int, int], tile_size: int
+        self, point: tuple[int, int], tile_size: int | float
     ) -> shapely.Polygon:
         return shapely.Polygon(
             [
@@ -398,7 +398,8 @@ class SlideLoader:
         tile_size: int,
         cnts: list[shapely.Geometry],
     ):
-        tile = self._point_to_square_polygon(coords, tile_size)
+        tile_size_level0 = tile_size * float(self.ts.value)
+        tile = self._point_to_square_polygon(coords, tile_size_level0)
         has_roi = any([cnt.intersects(tile) for cnt in cnts])
         if not has_roi:
             return False

--- a/src/classpose/entrypoints/predict_wsi.py
+++ b/src/classpose/entrypoints/predict_wsi.py
@@ -42,6 +42,7 @@ import argparse
 import json
 import logging
 import re
+import threading
 import time
 import uuid
 from pathlib import Path
@@ -149,7 +150,7 @@ class SlideLoader:
             manager = tmproc.Manager()
 
         self.n = manager.Value("i", 0)
-        self.q = manager.Queue(maxsize=MAX_QUEUE_SIZE)
+        self.q = tmproc.Queue(maxsize=MAX_QUEUE_SIZE)
         self.ts = manager.Value("f", 0)
         self.mpp_x = manager.Value("f", 0)
         self.mpp_y = manager.Value("f", 0)
@@ -157,6 +158,7 @@ class SlideLoader:
         self.bounds_y = manager.Value("f", 0)
         self.tissue_cnts = manager.list()
         self.roi_cnts = manager.list()
+        self.resize_factor = manager.Value("f", 1.0)
 
         self.p = tmproc.Process(target=self.fill_queue)
         self.p.start()
@@ -209,26 +211,36 @@ class SlideLoader:
         self.level = self.slide.get_best_level_for_downsample(target_downsample)
         self.slide_dim = self.slide.level_dimensions[self.level]
         self.ts.value = self.slide.level_downsamples[self.level]
+        self.resize_factor.value = self.ts.value / target_downsample
+        read_tile_size = max(
+            1, round(self.tile_size / self.resize_factor.value)
+        )
+        read_overlap = max(0, round(self.overlap / self.resize_factor.value))
         if self.roi_tree is not None:
             self.coords = list(
                 self._get_coords_roi(
-                    self.tile_size, self.overlap, self.slide_dim, self.ts.value
+                    read_tile_size, read_overlap, self.slide_dim, self.ts.value
                 )
             )
         else:
             self.coords = list(
                 self._get_coords(
-                    self.tile_size, self.overlap, self.slide_dim, self.ts.value
+                    read_tile_size, read_overlap, self.slide_dim, self.ts.value
                 )
             )
-        logger.info(f"Slide mpp: {self.mpp}")
+        logger.info(f"Slide MPP: {self.mpp}")
+        logger.info(f"Model MPP: {self.train_mpp}")
         logger.info(f"Number of tiles: {len(self.coords)}")
         logger.info(f"Slide dimensions: {self.slide_dim}")
         logger.info(f"Tile size: {self.tile_size}")
         logger.info(f"Overlap: {self.overlap}")
-        logger.info(f"Target downsample: {target_downsample}")
-        logger.info(f"Slide downsample: {self.ts.value}")
-        logger.info(f"Level: {self.level}")
+        logger.info(f"Desired scale from MPP: {target_downsample}")
+        logger.info(f"Selected level: {self.level}")
+        logger.info(f"Selected level downsample: {self.ts.value}")
+        logger.info(
+            "Residual resize factor before inference: %s",
+            self.ts.value / target_downsample,
+        )
 
     def _align_roi_tree_to_slide_bounds(self):
         """
@@ -402,6 +414,7 @@ class SlideLoader:
                 if tile_array.shape[-1] == 4:
                     tile_array = tile_array[:, :, :3]
 
+                tile_array = self._resize_tile_to_target_mpp(tile_array)
                 self.q.put((tile_array, coords))
                 n += 1
                 self.n.value += 1
@@ -410,6 +423,27 @@ class SlideLoader:
             self.q.put((None, None))
         if self.termination_event is not None:
             self.termination_event.wait()
+
+    def _resize_tile_to_target_mpp(self, tile: np.ndarray) -> np.ndarray:
+        """
+        Resize a tile so that its apparent MPP matches the model MPP.
+
+        Args:
+            tile (np.ndarray): Tile read from the selected pyramid level.
+
+        Returns:
+            np.ndarray: Resized tile.
+        """
+        resize_factor = self.resize_factor.value
+        if resize_factor == 1.0:
+            return tile
+        new_width = max(1, int(round(tile.shape[1] * resize_factor)))
+        new_height = max(1, int(round(tile.shape[0] * resize_factor)))
+        return cv2.resize(
+            tile,
+            (new_width, new_height),
+            interpolation=cv2.INTER_LINEAR,
+        )
 
     def __iter__(self):
         """
@@ -452,35 +486,49 @@ class PostProcessor:
     6. Adding the polygons to a list for later writing to a GeoJSON file.
     """
 
-    def __init__(self, labels: list[str], manager: tmproc.Manager = None):
+    def __init__(
+        self,
+        labels: list[str],
+        manager: tmproc.Manager = None,
+        n_workers: int = 1,
+    ):
         """
         Args:
             labels (list[str]): Ordered list of labels for the classes.
                 Background (0) should not be included.
             manager (tmproc.Manager, optional): Manager to use for shared memory.
+            n_workers (int, optional): Number of inference workers that will send a None
+                sentinel when done. Defaults to 1.
         """
         self.labels = labels
+        self.n_workers = n_workers
 
         if manager is None:
             manager = tmproc.Manager()
 
         self.n = manager.Value("i", 0)
-        self.polygons = manager.Queue()
+        self.polygons = tmproc.Queue()
         self.value = manager.Value("i", 0)
         self.n_cells = manager.Value("i", 0)
         self.n_invalid_cells = manager.Value("i", 0)
-        self.q = manager.Queue()
-        self.p = tmproc.Process(target=self.run)
+        self.q = tmproc.Queue(maxsize=MAX_QUEUE_SIZE)
+        self.p = tmproc.Process(
+            target=self.run, args=(self.n_workers, self.labels)
+        )
         self.p.start()
 
-    def run(self):
+    def run(self, n_workers: int = 1):
         """
         Generic run method for the process.
         """
+        sentinels_remaining = n_workers
         while True:
             item = self.q.get()
             if item is None:
-                break
+                sentinels_remaining -= 1
+                if sentinels_remaining == 0:
+                    break
+                continue
             self(*item)
 
     def put(self, data: list[tuple]):
@@ -496,7 +544,7 @@ class PostProcessor:
         self,
         data: list[tuple[np.ndarray, np.ndarray]],
         batch_coords: list[tuple[int, int]],
-        ts: float,
+        target_downsample: float,
     ):
         """
         Data preprocessing following the aforementioned protocol. Appends everything
@@ -504,9 +552,9 @@ class PostProcessor:
 
         Args:
             data (list[tuple]): Data to process. Should be a list of tuples, where each
-                tuple contains the instance mask and class mask.
+                tuple contains masks and class_masks.
             batch_coords (list[tuple[int, int]]): List of coordinates for the batch.
-            ts (float): Target downsample.
+            target_downsample (float): Level-0 pixels per prediction pixel.
         """
         for datum, coords in zip(data, batch_coords):
             masks, class_masks = datum
@@ -521,7 +569,7 @@ class PostProcessor:
                         cv2.RETR_EXTERNAL,
                         cv2.CHAIN_APPROX_SIMPLE,
                     )[0][0][:, 0]
-                    * ts
+                    * target_downsample
                     + coords
                 )
                 # discard invalid polygons as these cannot be read in QuPath
@@ -588,7 +636,7 @@ def worker(
         n_cells (tmproc.Value): tmp Value to count number of cells.
         n_invalid_cells (tmproc.Value): tmp Value to count number of invalid cells.
         bsize (int): Batch size.
-        target_downsample (float): Target downsample.
+        target_downsample (float): Level-0 pixels per prediction pixel.
     """
     model = ClassposeModel(
         gpu=dev.type == "cuda",
@@ -818,6 +866,8 @@ def shapely_polygon_to_geojson(
             )
         return features
 
+    if isinstance(polygon, shapely.LineString):
+        return []
     exterior = [list(pt) for pt in polygon.exterior.coords]
     interiors = [[list(pt) for pt in ring.coords] for ring in polygon.interiors]
     coordinates = [exterior, *interiors]
@@ -917,6 +967,11 @@ def load_roi_polygons(
     polys = []
     class_dict = {}
 
+    if isinstance(data, list):
+        data = {"features": data}
+    if "features" not in data and "geometry" in data:
+        data["features"] = [data]
+
     for feat in data.get("features", []):
         geom = feat.get("geometry")
         if not geom:
@@ -930,6 +985,11 @@ def load_roi_polygons(
             classification = props.get("classification", {})
             class_name = classification.get("name", "unknown")
 
+        if isinstance(shp, shapely.LineString):
+            coords = [(x, y) for x, y in zip(*shp.coords.xy)]
+            coords = coords + [coords[0]]
+            shp = shapely.Polygon(coords)
+            shp = shapely.make_valid(shp)
         if isinstance(shp, shapely.Polygon):
             polys.append(shp)
             if group_by_class:
@@ -1309,11 +1369,32 @@ def main(args):
         device=devices[0],
         termination_event=termination_event,
     )
-    pp = PostProcessor(labels=labels, manager=manager)
-    # Wait for slide to be initialized so that the target downsample is known
+    pp = PostProcessor(labels=labels, manager=manager, n_workers=len(devices))
+    # Wait for slide to be initialized so that the target scale is known
     while slide.ts.value == 0:
         time.sleep(0.1)
-    ts = float(slide.ts.value)
+    mpp_x = float(slide.mpp_x.value)
+    mpp_y = float(slide.mpp_y.value)
+    target_downsample = min(
+        model_config.mpp / mpp_x,
+        model_config.mpp / mpp_y,
+    )
+    logger.info(
+        "Prediction-to-slide coordinate scale: %s",
+        target_downsample,
+    )
+
+    collected_batches: list = []
+
+    def _drain_polygons():
+        while True:
+            item = pp.polygons.get()
+            if item is None:
+                break
+            collected_batches.append(item)
+
+    drain_thread = threading.Thread(target=_drain_polygons, daemon=True)
+    drain_thread.start()
 
     if len(devices) > 1:
         workers = []
@@ -1336,7 +1417,7 @@ def main(args):
                     pp.n_cells,
                     pp.n_invalid_cells,
                     256,
-                    ts,
+                    target_downsample,
                     args.bf16,
                 ),
             )
@@ -1359,22 +1440,25 @@ def main(args):
             n_cells=pp.n_cells,
             n_invalid_cells=pp.n_invalid_cells,
             bsize=256,
-            target_downsample=ts,
+            target_downsample=target_downsample,
             bf16=args.bf16,
         )
+
     pp.p.join()
+    slide.close()
+    pp.polygons.put(None)
+    drain_thread.join()
 
     polygons = []
     with tqdm(desc="Collecting polygons") as pbar:
-        for _ in range(pp.value.value):
-            polygons.extend([to_geojson_polygon(x) for x in pp.polygons.get()])
+        for batch in collected_batches:
+            polygons.extend([to_geojson_polygon(x) for x in batch])
             pbar.update()
     logger.info(f"Number of detected cells: {len(polygons)}")
     logger.info(f"Number of invalid cells: {pp.n_invalid_cells.value}")
     if len(polygons) == 0:
         logger.warning("No cells detected")
         logger.info("Exiting")
-        slide.close()
         return
 
     logger.info("Creating GeoJSON file")

--- a/src/classpose/entrypoints/predict_wsi.py
+++ b/src/classpose/entrypoints/predict_wsi.py
@@ -1415,6 +1415,7 @@ def main(args):
     # Wait for slide to be initialized so that the target scale is known
     while slide.ts.value == 0:
         time.sleep(0.1)
+    ts = float(slide.ts.value)
     mpp_x = float(slide.mpp_x.value)
     mpp_y = float(slide.mpp_y.value)
     target_downsample = min(
@@ -1458,6 +1459,7 @@ def main(args):
                     slide.n,
                     pp.n_cells,
                     pp.n_invalid_cells,
+                    ts,
                     256,
                     target_downsample,
                     args.bf16,

--- a/src/classpose/entrypoints/predict_wsi.py
+++ b/src/classpose/entrypoints/predict_wsi.py
@@ -500,7 +500,6 @@ class PostProcessor:
             n_workers (int, optional): Number of inference workers that will send a None
                 sentinel when done. Defaults to 1.
         """
-        self.labels = labels
         self.n_workers = n_workers
 
         if manager is None:
@@ -512,9 +511,7 @@ class PostProcessor:
         self.n_cells = manager.Value("i", 0)
         self.n_invalid_cells = manager.Value("i", 0)
         self.q = tmproc.Queue(maxsize=MAX_QUEUE_SIZE)
-        self.p = tmproc.Process(
-            target=self.run, args=(self.n_workers, self.labels)
-        )
+        self.p = tmproc.Process(target=self.run, args=(self.n_workers,))
         self.p.start()
 
     def run(self, n_workers: int = 1):

--- a/src/classpose/entrypoints/predict_wsi.py
+++ b/src/classpose/entrypoints/predict_wsi.py
@@ -1365,7 +1365,7 @@ def main(args):
 
     polygons = []
     with tqdm(desc="Collecting polygons") as pbar:
-        while not pp.polygons.empty():
+        for _ in range(pp.value.value):
             polygons.extend([to_geojson_polygon(x) for x in pp.polygons.get()])
             pbar.update()
     logger.info(f"Number of detected cells: {len(polygons)}")

--- a/src/classpose/entrypoints/predict_wsi_cpsam.py
+++ b/src/classpose/entrypoints/predict_wsi_cpsam.py
@@ -104,7 +104,7 @@ def worker(
     n_invalid_cells: tmproc.Value,
     slide_downsample: float = 1,
     bsize: int = 256,
-    target_downsample: float = 1,
+    prediction_to_slide_scale: float = 1,
     bf16: bool = False,
 ):
     """
@@ -125,7 +125,7 @@ def worker(
         n_invalid_cells (tmproc.Value): tmp Value to count number of invalid cells.
         slide_downsample (float): Pyramid downsample used to read tiles.
         bsize (int): Batch size.
-        target_downsample (float): Target downsample.
+        prediction_to_slide_scale (float): Level-0 pixels per prediction pixel.
         bf16 (bool): Whether to use bfloat16.
     """
     if isinstance(dev, str):
@@ -166,7 +166,9 @@ def worker(
                     batch_masks = masks
                 else:
                     batch_masks = [masks]
-                postproc_queue.put((batch_masks, [coords], target_downsample))
+                postproc_queue.put(
+                    (batch_masks, [coords], prediction_to_slide_scale)
+                )
                 predicted_tiles.value += 1
 
                 pbar.n = predicted_tiles.value
@@ -246,7 +248,10 @@ def main(args):
     ts = float(slide.ts.value)
     mpp_x = float(slide.mpp_x.value)
     mpp_y = float(slide.mpp_y.value)
-    target_downsample = min(args.train_mpp / mpp_x, args.train_mpp / mpp_y)
+    prediction_to_slide_scale = min(
+        args.train_mpp / mpp_x,
+        args.train_mpp / mpp_y,
+    )
 
     collected_batches: list = []
 
@@ -280,7 +285,7 @@ def main(args):
                     pp.n_invalid_cells,
                     ts,
                     256,
-                    target_downsample,
+                    prediction_to_slide_scale,
                     args.bf16,
                 ),
             )
@@ -302,7 +307,7 @@ def main(args):
             n_invalid_cells=pp.n_invalid_cells,
             slide_downsample=ts,
             bsize=256,
-            target_downsample=target_downsample,
+            prediction_to_slide_scale=prediction_to_slide_scale,
             bf16=args.bf16,
         )
 

--- a/src/classpose/entrypoints/predict_wsi_cpsam.py
+++ b/src/classpose/entrypoints/predict_wsi_cpsam.py
@@ -43,8 +43,8 @@ warnings.filterwarnings("ignore", message=".*Transforming to str index.*")
 import argparse
 import json
 import logging
+import threading
 import time
-import uuid
 from pathlib import Path
 from multiprocessing import Event
 
@@ -70,6 +70,8 @@ from classpose.entrypoints.predict_wsi import (
     DEFAULT_TILE_SIZE,
     DEFAULT_TRAIN_MPP,
     MIN_TILE_SIZE,
+    COLORMAP,
+    PostProcessor,
     SlideLoader,
     apply_bounds_offset_to_feature,
     deduplicate,
@@ -90,116 +92,6 @@ from classpose.utils import (
 from classpose import WSIReader
 
 logger = get_logger("classpose")
-
-
-class PostProcessor:
-    """
-    Post processor class for parallel post processing of tiles.
-
-    The workflow consists in:
-
-    1. Using the instance prediction to identify all cells in the tile
-    2. Using the cell coordinates to create a polygon for each cell
-    3. Filtering out invalid polygons as these represent unlikely predictions
-    (i.e. the contour crosses itself at a given point)
-    4. Extraction of some minimal features (area, perimeter, centroid) which
-    can be used for deduplicating cells at a later stage
-    5. Adding the polygons to a list for later writing to a GeoJSON file.
-    """
-
-    def __init__(self, manager: tmproc.Manager = None):
-        """
-        Args:
-            manager (tmproc.Manager, optional): Manager to use for shared memory.
-        """
-
-        if manager is None:
-            manager = tmproc.Manager()
-
-        self.n = manager.Value("i", 0)
-        self.polygons = manager.Queue()
-        self.value = manager.Value("i", 0)
-        self.n_cells = manager.Value("i", 0)
-        self.n_invalid_cells = manager.Value("i", 0)
-        self.q = manager.Queue()
-        self.p = tmproc.Process(target=self.run)
-        self.p.start()
-
-    def run(self):
-        """
-        Generic run method for the process.
-        """
-        while True:
-            item = self.q.get()
-            if item is None:
-                break
-            self(*item)
-
-    def put(self, data: list[tuple]):
-        """
-        Puts data in the queue.
-
-        Args:
-            data (list[tuple]): Data to put in the queue.
-        """
-        self.q.put(data)
-
-    def __call__(
-        self,
-        data: list[np.ndarray],
-        batch_coords: list[tuple[int, int]],
-        target_downsample: float,
-    ):
-        """
-        Data preprocessing following the aforementioned protocol. Appends everything
-        to the polygons list, which is a shared memory list.
-
-        Args:
-            data (list[np.ndarray]): Data to process. Should be a list of instance masks.
-            batch_coords (list[tuple[int, int]]): List of coordinates for the batch.
-            target_downsample (float): Level-0 pixels per prediction pixel.
-        """
-        class_name = "cell"
-        class_color = [0, 168, 132]
-        for masks, coords in zip(data, batch_coords):
-            u = np.unique(masks)
-            u = u[u > 0]
-            curr_cells = []
-            for i in u:
-                cell_mask = masks == i
-                curr_coords = (
-                    cv2.findContours(
-                        np.uint8(cell_mask),
-                        cv2.RETR_EXTERNAL,
-                        cv2.CHAIN_APPROX_SIMPLE,
-                    )[0][0][:, 0]
-                    * target_downsample
-                    + coords
-                )
-                # discard invalid polygons as these cannot be read in QuPath
-                if curr_coords.shape[0] < 4:
-                    self.n_invalid_cells.value += 1
-                    continue
-                polygon = shapely.Polygon(curr_coords)
-                if not polygon.is_valid:
-                    self.n_invalid_cells.value += 1
-                    continue
-                center = np.round(polygon.centroid.coords[0], 2).tolist()
-                curr_coords = curr_coords.tolist()
-                curr_coords.append(curr_coords[0].copy())
-                curr_cell = {
-                    "id": str(uuid.uuid4()),
-                    "coords": curr_coords,
-                    "area": polygon.area,
-                    "label": class_name,
-                    "color": class_color,
-                    "perimeter": polygon.length,
-                    "centroid": center,
-                }
-                curr_cells.append(curr_cell)
-            self.polygons.put(curr_cells)
-            self.n_cells.value += len(curr_cells)
-            self.value.value += 1
 
 
 def worker(
@@ -341,7 +233,8 @@ def main(args):
         device=devices[0],
         termination_event=termination_event,
     )
-    pp = PostProcessor(manager=manager)
+    pp = PostProcessor(manager=manager, n_workers=len(devices))
+
     # Wait for slide to be initialized so that the target downsample is known
     while slide.ts.value == 0:
         time.sleep(0.1)
@@ -349,6 +242,18 @@ def main(args):
     mpp_x = float(slide.mpp_x.value)
     mpp_y = float(slide.mpp_y.value)
     target_downsample = min(args.train_mpp / mpp_x, args.train_mpp / mpp_y)
+
+    collected_batches: list = []
+
+    def _drain_polygons():
+        while True:
+            item = pp.polygons.get()
+            if item is None:
+                break
+            collected_batches.append(item)
+
+    drain_thread = threading.Thread(target=_drain_polygons, daemon=True)
+    drain_thread.start()
 
     if len(devices) > 1:
         workers = []
@@ -395,13 +300,16 @@ def main(args):
             target_downsample=target_downsample,
             bf16=args.bf16,
         )
+
     pp.p.join()
     slide.close()
+    pp.polygons.put(None)
+    drain_thread.join()
 
     polygons = []
     with tqdm(desc="Collecting polygons") as pbar:
-        for _ in range(pp.value.value):
-            polygons.extend([to_geojson_polygon(x) for x in pp.polygons.get()])
+        for batch in collected_batches:
+            polygons.extend([to_geojson_polygon(x) for x in batch])
             pbar.update()
     logger.info("Number of detected cells: %s", len(polygons))
     logger.info("Number of invalid cells: %s", pp.n_invalid_cells.value)

--- a/src/classpose/entrypoints/predict_wsi_cpsam.py
+++ b/src/classpose/entrypoints/predict_wsi_cpsam.py
@@ -46,6 +46,7 @@ import logging
 import time
 import uuid
 from pathlib import Path
+from multiprocessing import Event
 
 import cv2
 import numpy as np
@@ -308,6 +309,7 @@ def worker(
 
 def main(args):
     tmproc.set_start_method("spawn", force=True)
+    termination_event = Event()
 
     if args.tile_size < MIN_TILE_SIZE:
         raise ValueError(
@@ -350,6 +352,7 @@ def main(args):
         min_area=args.min_area,
         roi_tree=roi_tree,
         device=devices[0],
+        termination_event=termination_event,
     )
     pp = PostProcessor(manager=manager)
     # Wait for slide to be initialized so that the target downsample is known

--- a/src/classpose/entrypoints/predict_wsi_cpsam.py
+++ b/src/classpose/entrypoints/predict_wsi_cpsam.py
@@ -76,7 +76,6 @@ from classpose.entrypoints.predict_wsi import (
     filter_cells_by_contours,
     load_roi_polygons,
     polygons_to_centroids,
-    resize_tile_to_target_mpp,
     shapely_polygon_to_geojson,
     to_geojson_polygon,
 )
@@ -147,12 +146,10 @@ def worker(
         position=1,
         total=0,
     ) as pbar:
-        resize_factor = slide_downsample / target_downsample
         while True:
             tile, coords = slide_queue.get()
             if tile is None:
                 break
-            tile = resize_tile_to_target_mpp(tile, resize_factor)
             masks, raw_data, styles = model.eval(
                 [tile],
                 batch_size=batch_size,

--- a/src/classpose/entrypoints/predict_wsi_cpsam.py
+++ b/src/classpose/entrypoints/predict_wsi_cpsam.py
@@ -390,7 +390,7 @@ def main(args):
 
     polygons = []
     with tqdm(desc="Collecting polygons") as pbar:
-        while not pp.polygons.empty():
+        for _ in range(pp.value.value):
             polygons.extend([to_geojson_polygon(x) for x in pp.polygons.get()])
             pbar.update()
     logger.info("Number of detected cells: %s", len(polygons))

--- a/src/classpose/entrypoints/predict_wsi_cpsam.py
+++ b/src/classpose/entrypoints/predict_wsi_cpsam.py
@@ -78,6 +78,7 @@ from classpose.entrypoints.predict_wsi import (
     load_roi_polygons,
     polygons_to_centroids,
     shapely_polygon_to_geojson,
+    to_geojson_polygon,
 )
 from classpose.grandqc.wsi_artefact_detection import detect_artefacts_wsi
 from classpose.log import get_logger
@@ -184,34 +185,15 @@ class PostProcessor:
                     continue
                 center = np.round(polygon.centroid.coords[0], 2).tolist()
                 curr_coords = curr_coords.tolist()
-                curr_coords.append(curr_coords[0])
+                curr_coords.append(curr_coords[0].copy())
                 curr_cell = {
-                    "type": "Feature",
                     "id": str(uuid.uuid4()),
-                    "geometry": {
-                        "type": "Polygon",
-                        "coordinates": [curr_coords],
-                    },
-                    "properties": {
-                        "objectType": "annotation",
-                        "isLocked": False,
-                        "classification": {
-                            "name": class_name,
-                            "color": class_color,
-                        },
-                        "measurements": [
-                            {"name": "area", "value": polygon.area},
-                            {"name": "perimeter", "value": polygon.length},
-                            {
-                                "name": "centroidX",
-                                "value": center[0],
-                            },
-                            {
-                                "name": "centroidY",
-                                "value": center[1],
-                            },
-                        ],
-                    },
+                    "coords": curr_coords,
+                    "area": polygon.area,
+                    "label": class_name,
+                    "color": class_color,
+                    "perimeter": polygon.length,
+                    "centroid": center,
                 }
                 curr_cells.append(curr_cell)
             self.polygons.put(curr_cells)
@@ -409,7 +391,7 @@ def main(args):
     polygons = []
     with tqdm(desc="Collecting polygons") as pbar:
         while not pp.polygons.empty():
-            polygons.extend(pp.polygons.get())
+            polygons.extend([to_geojson_polygon(x) for x in pp.polygons.get()])
             pbar.update()
     logger.info("Number of detected cells: %s", len(polygons))
     logger.info("Number of invalid cells: %s", pp.n_invalid_cells.value)

--- a/src/classpose/entrypoints/predict_wsi_cpsam.py
+++ b/src/classpose/entrypoints/predict_wsi_cpsam.py
@@ -41,6 +41,7 @@ warnings.filterwarnings("ignore", message=".*ImplicitModification.*")
 warnings.filterwarnings("ignore", message=".*Transforming to str index.*")
 
 import argparse
+import gc
 import json
 import logging
 import threading
@@ -127,57 +128,67 @@ def worker(
         target_downsample (float): Target downsample.
         bf16 (bool): Whether to use bfloat16.
     """
-    model = CellposeModel(
-        gpu=dev.type == "cuda",
-        pretrained_model=model_path,
-        device=dev,
-    )
-    if bf16:
-        model.net = model.net.to(torch.bfloat16)
     if isinstance(dev, str):
         dev = torch.device(dev)
-    if dev.type == "cuda":
-        model.net = model.net.to(dev)
-        model.net = torch.compile(model.net)
+    model = None
+    tile = masks = raw_data = styles = None
 
-    with tqdm(
-        None,
-        desc="Predicted tiles (detected cells: 0)",
-        position=1,
-        total=0,
-    ) as pbar:
-        while True:
-            tile, coords = slide_queue.get()
-            if tile is None:
-                break
-            masks, raw_data, styles = model.eval(
-                [tile],
-                batch_size=batch_size,
-                augment=tta,
-                bsize=bsize,
-                compute_masks=True,
-            )
-            if isinstance(masks, list):
-                batch_masks = masks
-            else:
-                batch_masks = [masks]
-            postproc_queue.put((batch_masks, [coords], target_downsample))
-            predicted_tiles.value += 1
+    try:
+        model = CellposeModel(
+            gpu=dev.type == "cuda",
+            pretrained_model=model_path,
+            device=dev,
+        )
+        if bf16:
+            model.net = model.net.to(torch.bfloat16)
+        if dev.type == "cuda":
+            model.net = model.net.to(dev)
+            model.net = torch.compile(model.net)
 
-            pbar.n = predicted_tiles.value
-            pbar.total = slide_queue_size.value
+        with tqdm(
+            None,
+            desc="Predicted tiles (detected cells: 0)",
+            position=1,
+            total=0,
+        ) as pbar:
+            while True:
+                tile, coords = slide_queue.get()
+                if tile is None:
+                    break
+                masks, raw_data, styles = model.eval(
+                    [tile],
+                    batch_size=batch_size,
+                    augment=tta,
+                    bsize=bsize,
+                    compute_masks=True,
+                )
+                if isinstance(masks, list):
+                    batch_masks = masks
+                else:
+                    batch_masks = [masks]
+                postproc_queue.put((batch_masks, [coords], target_downsample))
+                predicted_tiles.value += 1
+
+                pbar.n = predicted_tiles.value
+                pbar.total = slide_queue_size.value
+                pbar.set_description(
+                    "Predicted tiles (detected cells: %s; invalid: %s)"
+                    % (n_cells.value, n_invalid_cells.value)
+                )
+                pbar.refresh()
+
             pbar.set_description(
                 "Predicted tiles (detected cells: %s; invalid: %s)"
                 % (n_cells.value, n_invalid_cells.value)
             )
-            pbar.refresh()
-
+            print()
+    finally:
+        tile = masks = raw_data = styles = None
+        model = None
+        gc.collect()
+        if dev.type == "cuda":
+            torch.cuda.empty_cache()
         postproc_queue.put(None)
-        pbar.set_description(
-            "Predicted tiles (detected cells: %s; invalid: %s)"
-            % (n_cells.value, n_invalid_cells.value)
-        )
-        print()
 
 
 def main(args):

--- a/src/classpose/entrypoints/predict_wsi_cpsam.py
+++ b/src/classpose/entrypoints/predict_wsi_cpsam.py
@@ -48,8 +48,6 @@ import time
 from pathlib import Path
 from multiprocessing import Event
 
-import cv2
-import numpy as np
 import shapely
 import torch
 import torch.multiprocessing as tmproc
@@ -70,7 +68,6 @@ from classpose.entrypoints.predict_wsi import (
     DEFAULT_TILE_SIZE,
     DEFAULT_TRAIN_MPP,
     MIN_TILE_SIZE,
-    COLORMAP,
     PostProcessor,
     SlideLoader,
     apply_bounds_offset_to_feature,

--- a/src/classpose/train_utils.py
+++ b/src/classpose/train_utils.py
@@ -32,11 +32,11 @@ def _filter_labels_and_images(
         tuple[list[np.ndarray], list[np.ndarray]]: Tuple of filtered images and labels.
     """
     remove = []
-    for label in tqdm(
+    for curr_label in tqdm(
         labels,
         desc="Filtering out labels and images with a single annotated pixel...",
     ):
-        instances = label[0]
+        instances = curr_label[0]
         if np.nonzero(instances)[0].size == 1:
             remove.append(True)
         else:
@@ -46,7 +46,7 @@ def _filter_labels_and_images(
             f"Removed {sum(remove)} images with a single pixel instance"
         )
     return [image for image, r in zip(images, remove) if not r], [
-        label for label, r in zip(labels, remove) if not r
+        curr_label for curr_label, r in zip(labels, remove) if not r
     ]
 
 
@@ -454,7 +454,9 @@ def get_class_weights(class_counts: np.ndarray) -> np.ndarray:
     )
     positive_counts = class_counts[class_counts > 0]
     if positive_counts.size == 0:
-        raise ValueError("Cannot compute class weights with no positive class counts")
+        raise ValueError(
+            "Cannot compute class weights with no positive class counts"
+        )
     median_count = np.median(positive_counts)
     inv_freq = np.zeros_like(class_counts, dtype=np.float64)
     inv_freq[class_counts > 0] = median_count / class_counts[class_counts > 0]


### PR DESCRIPTION
This fixes some multi-processing related issues which might happen when the number of tiles is too large and processes get terminated earlier than they should. 

The concrete set of changes implemented here are as follows:

1. SlideLoader now uses a termination event to avoid the process from exiting too early
2. Queues are no longer managed by the parent process Manager and are instead instantiated from `torch.multiprocessing`
3. Drains polygons as they are appended to the polygon Queue. This prevents the Queue from getting excessively full of objects which are relatively large
4. Implements the same changes to `predict_wsi_cpsam.py`

Bonus fixes:

1. Refactored resizing of tiles to happen always during the tile-reading (better overlap with GPU compute)
2. Ensures that the input to Classpose is always the specified `--tile_size` rather than `--tile_size` multiplied by whatever the rescaling factor is
3. Adds some additional support for specific GeoJSON format, namely: GeoJSON is just a list of features, GeoJSON is an array of features (rather than an array which has a "features" key)
5. Attempts to close LineStrings coming from poorly formatted input region ROIs (this might be controversial! I ran into this issue a few times with specific annotations)
6. Minimal linting changes